### PR TITLE
Shift image column ROI

### DIFF
--- a/app/bbox_map.py
+++ b/app/bbox_map.py
@@ -19,7 +19,8 @@ BB = {
     "COL_QTY"        : (  30,  430,    70,  875),   # Quantity column
     "COL_CODE"       : (  70,  430,   150,  875),   # 3-digit/decimal product code
     "COL_DESC"       : ( 150,  430,   550,  875),   # Long description text
-    "COL_IMG"        : ( 550,  430,   700,  875),   # 4-digit image IDs (comma-sep)
+    # Shifted right by half the original width to fully capture image codes
+    "COL_IMG"        : ( 625,  430,   775,  875),   # 4-digit image IDs (comma-sep)
     # ---------- (Ignore ArtistSeries, Frames, Retouch blocks for now) ----
 }
 


### PR DESCRIPTION
## Summary
- move COL_IMG bounding box right by half its width to capture entire column

## Testing
- `pytest -q` *(fails: ImportError: numpy.core.multiarray failed to import)*

------
https://chatgpt.com/codex/tasks/task_e_68867aecd3d4832da67bca47a1a11805