### PR TITLE
Implement frame color OCR & retouch fixes

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -14,7 +14,12 @@ import math
 from .trio_composite import TrioCompositeGenerator, is_trio_product
 
 # Import frame overlay functionality
-from .frame_overlay import FrameOverlayEngine, FrameSpec, create_frame_overlay_engine
+from .frame_overlay import (
+    FrameOverlayEngine,
+    FrameSpec,
+    create_frame_overlay_engine,
+    apply_frames_simple,
+)
 
 
 class EnhancedPortraitPreviewGenerator:
@@ -1708,8 +1713,10 @@ class EnhancedPortraitPreviewGenerator:
             processed_items = items
             if frame_requirements:
                 logger.info(f"Applying frame requirements: {frame_requirements}")
-                processed_items = self.frame_engine.apply_frames_to_order_items(items, frame_requirements, frame_style_preferences)
-                logger.info(f"Processed items: {len(items)} -> {len(processed_items)} (after frame application)")
+                processed_items = apply_frames_simple(items, frame_requirements)
+                logger.info(
+                    f"Processed items: {len(items)} -> {len(processed_items)} (after frame application)"
+                )
             
             # STEP 5: Process all images to canonical portrait orientation and master crops
             self._process_images(processed_items)

--- a/app/frame_overlay.py
+++ b/app/frame_overlay.py
@@ -473,4 +473,31 @@ class FrameOverlayEngine:
 def create_frame_overlay_engine() -> FrameOverlayEngine:
     """Factory function to create a frame overlay engine"""
     frames_dir = Path("Frames")
-    return FrameOverlayEngine(frames_dir) 
+    return FrameOverlayEngine(frames_dir)
+
+
+def apply_frames_simple(order_items: List[Dict], frame_counts: Dict[str, Dict[str, int]]) -> List[Dict]:
+    """Assign frame colors to order items based on parsed counts.
+
+    This helper does not split pairs or handle complex cases. It simply assigns
+    available Cherry frames first, then Black, decreasing the counts as frames
+    are used.
+    """
+
+    for item in order_items:
+        size = item.get("size", "").replace(" ", "")
+        if size in frame_counts:
+            counts = frame_counts[size]
+            if isinstance(counts, int):
+                counts = {"black": counts}
+                frame_counts[size] = counts
+
+            chosen = None
+            for color in ("cherry", "black"):
+                if counts.get(color, 0) > 0:
+                    counts[color] -= 1
+                    chosen = color.capitalize()
+                    break
+            if chosen:
+                item["frame_color"] = chosen
+    return order_items


### PR DESCRIPTION
## Summary
- parse frame and retouch tables from screenshot
- expose Artist Series flag and log frame/retouch info
- simple frame assignment helper with color support
- use helper in preview generator

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_688684dc25c4832d931c70d8e411d469