### PR TITLE
Add frame eligibility for 5x7 pair and tighten mapping test

### DIFF
--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -1,0 +1,100 @@
+from typing import Dict, List
+
+# Simple product specification used for tests
+PRODUCT_SPECS = {
+    'wallets_8_sheet': {
+        'name': 'Wallet Sheet of 8',
+        'size': '5x7',
+        'category': 'sheet',
+    },
+    '5x7_pair': {
+        'name': '5x7 Pair',
+        'size': '5x7',
+        'category': 'sheet',
+        'frame_eligible': True,
+        'frame_qty': 2,
+    },
+    '3.5x5_sheet4': {
+        'name': '3.5x5 Sheet of 4',
+        'size': '3.5x5',
+        'category': 'sheet',
+    },
+    '8x10_basic': {
+        'name': '8x10 Basic',
+        'size': '8x10',
+        'category': 'print',
+    },
+    '16x20_basic': {
+        'name': '16x20 Basic',
+        'size': '16x20',
+        'category': 'print',
+    },
+    '10x13_basic': {
+        'name': '10x13 Basic',
+        'size': '10x13',
+        'category': 'print',
+    },
+    '20x24_basic': {
+        'name': '20x24 Basic',
+        'size': '20x24',
+        'category': 'print',
+    },
+    '10x20_trio': {
+        'name': '10x20 Trio',
+        'size': '10x20',
+        'category': 'trio_composite',
+    },
+    '5x10_trio': {
+        'name': '5x10 Trio',
+        'size': '5x10',
+        'category': 'trio_composite',
+    },
+}
+
+def expand_row_to_items(row: Dict, product_specs: Dict[str, Dict] = PRODUCT_SPECS) -> List[Dict]:
+    """Expand a row definition into individual items preserving image order."""
+    imgs = [c.strip() for c in row.get('imgs', '').split(',') if c.strip()]
+    qty = int(row.get('qty', 0))
+    code = row.get('code')
+    spec = product_specs.get(code, {})
+    items: List[Dict] = []
+    for _ in range(qty):
+        entry = {
+            'product_code': code,
+            'product_name': spec.get('name', code),
+            'size': spec.get('size', ''),
+            'images': imgs.copy(),
+            'category': spec.get('category', ''),
+            'frame_qty': spec.get('frame_qty', 1),
+        }
+        if 'frame_eligible' in spec:
+            entry['frame_eligible'] = spec['frame_eligible']
+        items.append(entry)
+    return items
+
+def apply_frames_to_items(items: List[Dict], frame_counts: Dict[str, Dict[str, int]]):
+    """Assign frames to items consuming counts and preferring labeled colors."""
+    for it in items:
+        # Skip composites entirely. Respect explicit frame_eligible flag if set.
+        if it.get('category') == 'trio_composite':
+            continue
+        if not it.get('frame_eligible', it.get('category') == 'print'):
+            continue
+        key = it.get('size', '').replace(' ', '')
+        pool = frame_counts.get(key)
+        if not pool:
+            continue
+        desired = None
+        name = it.get('product_name', '').lower()
+        if 'cherry' in name:
+            desired = 'cherry'
+        elif 'black' in name:
+            desired = 'black'
+        qty = it.get('frame_qty', 1)
+        for _ in range(qty):
+            for color in ([desired] if desired else ['cherry', 'black']):
+                if pool.get(color, 0) > 0:
+                    it['frame_color'] = color.capitalize()
+                    pool[color] -= 1
+                    break
+    return items

--- a/tests/test_ocr_mapping.py
+++ b/tests/test_ocr_mapping.py
@@ -1,0 +1,130 @@
+from app.order_utils import expand_row_to_items, apply_frames_to_items
+
+EXPECTED = {
+    '0033': {
+        'Wallet Sheet of 8': 12,
+        '5x7 Pair': 1,
+        '3.5x5 Sheet of 4': 3,
+        '8x10 Basic': 1,
+        '16x20 Basic': 1,
+        'retouch': True,
+        'artist': True,
+    },
+    '0102': {
+        '10x13 Basic': 1,
+        '20x24 Basic': 1,
+        'retouch': False,
+        'artist': False,
+    },
+    '0044': {'retouch': False, 'artist': False},
+    '0039': {'retouch': False, 'artist': False},
+}
+
+EXPECTED_FRAMES_START = {
+    '5x7': {'cherry': 2},
+    '8x10': {'black': 2},
+    '10x13': {'black': 1},
+}
+
+EXPECTED_FRAMES_LEFT = {
+    '5x7': {'cherry': 0},
+    '8x10': {'black': 1},
+    '10x13': {'black': 0},
+}
+
+EXPECTED_COMPOSITES = {
+    '10x20 Trio': ['0033', '0044', '0039'],
+    '5x10 Trio #1': ['0039', '0033', '0044'],
+    '5x10 Trio #2': ['0039', '0033', '0044'],
+    '5x10 Trio #3': ['0039', '0033', '0044'],
+}
+
+# Sample rows based on OCR extraction
+ROWS = [
+    {'code': 'wallets_8_sheet', 'qty': 12, 'imgs': '0033'},
+    {'code': '5x7_pair', 'qty': 1, 'imgs': '0033'},
+    {'code': '3.5x5_sheet4', 'qty': 3, 'imgs': '0033'},
+    {'code': '8x10_basic', 'qty': 1, 'imgs': '0033'},
+    {'code': '16x20_basic', 'qty': 1, 'imgs': '0033'},
+    {'code': '10x13_basic', 'qty': 1, 'imgs': '0102'},
+    {'code': '20x24_basic', 'qty': 1, 'imgs': '0102'},
+]
+
+COMPOSITES = [
+    {'product_code': '10x20_trio', 'product_name': '10x20 Trio', 'size': '10x20', 'images': ['0033', '0044', '0039'], 'category': 'trio_composite'},
+    {'product_code': '5x10_trio', 'product_name': '5x10 Trio #1', 'size': '5x10', 'images': ['0039', '0033', '0044'], 'category': 'trio_composite'},
+    {'product_code': '5x10_trio', 'product_name': '5x10 Trio #2', 'size': '5x10', 'images': ['0039', '0033', '0044'], 'category': 'trio_composite'},
+    {'product_code': '5x10_trio', 'product_name': '5x10 Trio #3', 'size': '5x10', 'images': ['0039', '0033', '0044'], 'category': 'trio_composite'},
+]
+
+FRAME_COUNTS = {
+    '5x7': {'cherry': 2},
+    '8x10': {'black': 2},
+    '10x13': {'black': 1},
+}
+
+ARTIST_CODES = {'0033'}
+RETOUCH_CODES = {'0033'}
+
+
+def count_items_by_image(items):
+    out = {}
+    for it in items:
+        name = it['product_name']
+        for code in it['images']:
+            out.setdefault(code, {}).setdefault(name, 0)
+            out[code][name] += 1
+    return out
+
+
+def test_mapping():
+    items = []
+    for row in ROWS:
+        items.extend(expand_row_to_items(row))
+    items.extend(COMPOSITES)
+
+    import copy
+    start_counts = copy.deepcopy(FRAME_COUNTS)
+    apply_frames_to_items(items, FRAME_COUNTS)
+
+    for it in items:
+        codes = set(it['images'])
+        if it.get('category') == 'trio_composite':
+            it['artist_series'] = False
+            it['retouch'] = False
+        else:
+            it['artist_series'] = bool(codes & ARTIST_CODES)
+            it['retouch'] = bool(codes & RETOUCH_CODES)
+
+    got = count_items_by_image(items)
+    for code, spec in EXPECTED.items():
+        for prod, qty in spec.items():
+            if prod in ('retouch', 'artist'):
+                continue
+            assert got.get(code, {}).get(prod, 0) == qty, f"{code} {prod} wrong"
+
+    # ensure 0039 and 0044 only appear in composites
+    for leak_code in ('0039', '0044'):
+        for name in got.get(leak_code, {}):
+            assert 'Trio' in name, f"{leak_code} used in single item {name}"
+
+    # check retouch and artist flags
+    for it in items:
+        codes = set(it['images'])
+        if it.get('category') == 'trio_composite':
+            assert not it.get('retouch', False)
+            assert not it.get('artist_series', False)
+            continue
+        if codes & {'0033'}:
+            assert it['retouch'] is True
+            assert it['artist_series'] is True
+        else:
+            assert not it.get('retouch', False)
+            assert not it.get('artist_series', False)
+
+    assert start_counts == EXPECTED_FRAMES_START
+    assert FRAME_COUNTS == EXPECTED_FRAMES_LEFT
+
+    for comp in COMPOSITES:
+        name = comp['product_name']
+        assert EXPECTED_COMPOSITES[name] == comp['images']


### PR DESCRIPTION
## Summary
- mark 5x7 Pair products as frame eligible and require two frames
- copy frame flags when expanding items
- consume frame counts based on item `frame_qty`
- extend mapping test with leftover frame assertions and composite checks

## Testing
- `pytest tests/test_ocr_mapping.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c6064c18832d8d823b851189b60a