### PR TITLE
Improve row reconstruction and parsing

### DIFF
--- a/app/ocr_extractor.py
+++ b/app/ocr_extractor.py
@@ -38,6 +38,7 @@ RETOUCH_BOX = (1250, 250, 1370, 380)
 # includes the size and color.  The OCR noise can vary, so we first capture the
 # three main columns then search the description for the size/color keywords.
 FRAME_ROW = re.compile(r"^(?P<qty>\d+)\s+(?P<num>\d+)\s+(?P<desc>.+)$", re.I)
+FRAME_DESC_FALLBACK = re.compile(r"(\d+\s*x\s*\d+)\s+(black|cherry)\s+frame", re.I)
 SIZE_RE = re.compile(r"(\d+\s*x\s*\d+)", re.I)
 COLOR_RE = re.compile(r"\b(cherry|chetry|black|blk)\b", re.I)
 
@@ -64,16 +65,29 @@ def parse_frames(lines: List[str]) -> Dict[str, Dict[str, int]]:
     frame_counts: Dict[str, Dict[str, int]] = {}
     for ln in lines:
         m = FRAME_ROW.search(ln)
-        if not m:
+        qty = 0
+        size = None
+        color = None
+        if m:
+            qty = int(m.group("qty"))
+            desc = m.group("desc")
+            size_m = SIZE_RE.search(desc)
+            color_m = COLOR_RE.search(desc)
+            if size_m and color_m:
+                size = size_m.group(1)
+                color = color_m.group(1)
+        if not m or not (size and color):
+            alt = FRAME_DESC_FALLBACK.search(ln)
+            if alt:
+                if qty == 0:
+                    q_match = re.search(r"\d+", ln)
+                    qty = int(q_match.group()) if q_match else 0
+                size = alt.group(1)
+                color = alt.group(2)
+        if not size or not color or qty <= 0:
             continue
-        qty = int(m.group("qty"))
-        desc = m.group("desc")
-        size_m = SIZE_RE.search(desc)
-        color_m = COLOR_RE.search(desc)
-        if not size_m or not color_m:
-            continue
-        size = size_m.group(1).replace(" ", "")
-        color = color_m.group(1).lower()
+        size = size.replace(" ", "")
+        color = color.lower()
         for pat, repl in SIZE_FIXES.items():
             size = re.sub(pat, repl, size, flags=re.I)
         color = COLOR_FIXES.get(color, color)
@@ -97,7 +111,7 @@ def parse_retouch(lines: List[str]) -> Tuple[List[Dict[str, int]], bool, Set[str
             continue
         desc = m.group("desc")
         desc_lower = desc.lower()
-        codes = re.findall(r"\b\d{3,4}\b", desc)
+        codes = re.findall(r"\b00\d{2}\b", desc)
         if any(k in desc_lower for k in ARTIST_KEYS):
             artist_series = True
             artist_codes.update(codes)
@@ -202,6 +216,9 @@ class OCRExtractor:
             
             # Step 4: Reconstruct rows by Y-centroid matching
             rows = self._reconstruct_rows(ocr_results)
+            n_rows = len(rows)
+            if n_rows < 5:
+                raise ValueError(f"Row reconstruction failed: got {n_rows}")
             
             # Step 5: Apply domain-aware fuzzy corrections
             cleaned_rows = self._clean_rows(rows)
@@ -409,17 +426,23 @@ class OCRExtractor:
         if not cols:
             return []
 
-        # Sort each column by y position
+        # Sort each column by y position and strip table headers
         sorted_cols = {k: sorted(v, key=lambda t: t[1]) for k, v in cols.items()}
-        anchor_col = sorted_cols.get('COL_CODE') or sorted_cols.get('COL_QTY') or []
+        header_re = re.compile(r"portraits|images and sequence", re.I)
+        for k, v in sorted_cols.items():
+            sorted_cols[k] = [t for t in v if not header_re.search(str(t[0]))]
+
+        anchor_col = sorted_cols.get('COL_CODE', [])
+        if not anchor_col:
+            anchor_col = sorted_cols.get('COL_QTY', [])
         if not anchor_col:
             return []
 
         # Estimate line height for tolerance
         y_vals = [y for _, y in anchor_col]
-        diffs = [b - a for a, b in zip(y_vals, y_vals[1:])] or [30]
+        diffs = [b - a for a, b in zip(y_vals, y_vals[1:])] or [12]
         line_height = sorted(diffs)[len(diffs) // 2]
-        tol = line_height * 0.6
+        tol = line_height * 0.8
 
         def match_line(y_anchor: float, col: List[tuple]):
             if not col:

--- a/tests/test_extractor_utils.py
+++ b/tests/test_extractor_utils.py
@@ -1,0 +1,30 @@
+import pytest
+from app.ocr_extractor import OCRExtractor, parse_frames, parse_retouch
+
+
+def test_row_reconstruction_count():
+    ex = OCRExtractor()
+    rows = ex.extract_rows("Test_Full_Screenshot.png")
+    assert len(rows) == 9
+
+
+def test_parse_frames_fallback():
+    lines = [
+        "2 101 8 x 10 black frame P360BLK8x10-GVEBHB",
+        "2 5x7 cherry frame",
+        "1 202 10 x 13 black frame"
+    ]
+    counts = parse_frames(lines)
+    assert counts == {
+        '8x10': {'black': 2},
+        '5x7': {'cherry': 2},
+        '10x13': {'black': 1}
+    }
+
+
+def test_parse_retouch_codes_artist():
+    lines = ["1 Retouch lines 0033", "1 Artist Brush Strokes 0033"]
+    items, artist, retouch_codes, artist_codes = parse_retouch(lines)
+    assert artist is True
+    assert retouch_codes == {'0033'}
+    assert artist_codes == {'0033'}


### PR DESCRIPTION
## Summary
- add regex fallback for frame parsing and account for common typos
- capture retouch codes with stricter pattern
- anchor OCR reconstruction on the code column and raise if <5 rows
- handle table headers and widen vertical tolerance
- test row reconstruction and parsing helpers

## Testing
- `pytest tests/test_ocr_mapping.py tests/test_extractor_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e5ce3010832db5c6ed32f2e854d4