### PR TITLE
Improve row reconstruction and parsing

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -2970,13 +2970,6 @@ class EnhancedPortraitPreviewGenerator:
 
     def _is_retouch(self, image_codes: List[str], item: Dict | None = None) -> bool:
         """Check if an item or its images are flagged for retouch."""
-        if item and item.get('retouch'):
-            return True
-
-        # Fallback to legacy list based on image codes
-        retouch_list = ['0033', '0039']
-        for code in image_codes:
-            if code in retouch_list:
-                return True
-
+        if item:
+            return bool(item.get('retouch'))
         return False

--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -79,7 +79,8 @@ def apply_frames_to_items(items: List[Dict], frame_counts: Dict[str, Dict[str, i
         # Skip composites; respect frame_eligible flag (default True for prints).
         if it.get('category') == 'trio_composite':
             continue
-        if not it.get('frame_eligible', it.get('category') == 'print'):
+        default_eligible = it.get('category') in {'print', 'sheet'}
+        if not it.get('frame_eligible', default_eligible):
             continue
         key = it.get('size', '').replace(' ', '')
         pool = frame_counts.get(key)

--- a/tests/test_ocr_mapping.py
+++ b/tests/test_ocr_mapping.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from app.order_utils import expand_row_to_items, apply_frames_to_items
+from app.ocr_extractor import OCRExtractor
 
 EXPECTED = {
     '0033': {
@@ -125,3 +127,14 @@ def test_mapping():
     for comp in COMPOSITES:
         name = comp['product_name']
         assert EXPECTED_COMPOSITES[name] == comp['images']
+
+
+def test_row_reconstruction(temp_work_dir):
+    extractor = OCRExtractor()
+    cols = {}
+    for c in ['COL_QTY', 'COL_CODE', 'COL_DESC', 'COL_IMG']:
+        data = extractor._mock_ocr_result(c)
+        cols[c] = [(d['text'], d['y_position']) for d in data]
+    rows = extractor._reconstruct_rows(cols)
+    assert len(rows) == 9
+    assert rows[0].imgs == '0033'


### PR DESCRIPTION
## Summary
- update row reconstruction to skip headers, adjust tolerance, and assert row count
- refine retouch and artist code parsing
- improve frame parsing fallback regex
- handle default frame eligibility for prints and sheets
- rely solely on item flags for retouch overlay
- expand OCR mapping tests with reconstruction check

## Testing
- `pytest tests/test_ocr_mapping.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e5ce3010832db5c6ed32f2e854d4