### PR TITLE
Improve OCR resilience

### DIFF
--- a/app/ocr_extractor.py
+++ b/app/ocr_extractor.py
@@ -74,7 +74,7 @@ RETOUCH_BOX = (1250, 250, 1370, 380)
 # FRAMES table contains quantity, frame number and a free form description that
 # includes the size and color.  The OCR noise can vary, so we first capture the
 # three main columns then search the description for the size/color keywords.
-FRAME_ROW = re.compile(r"^(?P<qty>\d+)\s+(?P<num>\d+)\s+(?P<desc>.+)$", re.I)
+FRAME_ROW = re.compile(r"^(?P<qty>\d+)\s+\S+\s+(?P<desc>.+)$", re.I)
 SIZE_RE = re.compile(r"(\d+\s*x\s*\d+)", re.I)
 COLOR_RE = re.compile(r"\b(cherry|chetry|black|blk)\b", re.I)
 
@@ -98,6 +98,7 @@ ARTIST_KEYS = ["artist brush", "artist series"]
 
 def parse_frames(lines: List[str]) -> Dict[str, Dict[str, int]]:
     """Parse frame counts from OCR lines."""
+    logger.debug("FRAMES raw lines:\n" + "\n".join(lines))
     frame_counts: Dict[str, Dict[str, int]] = {}
     for ln in lines:
         m = FRAME_ROW.search(ln)
@@ -105,12 +106,22 @@ def parse_frames(lines: List[str]) -> Dict[str, Dict[str, int]]:
             continue
         qty = int(m.group("qty"))
         desc = m.group("desc")
+        desc_lower = desc.lower()
         size_m = SIZE_RE.search(desc)
         color_m = COLOR_RE.search(desc)
-        if not size_m or not color_m:
+        if not size_m:
+            size_value = next((kw for kw in ["5x7", "8x10", "10x20", "5x10", "10x13", "16x20", "20x24"] if kw in desc_lower), None)
+        else:
+            size_value = size_m.group(1)
+
+        if not color_m:
+            color_value = next((kw for kw in ["cherry", "black", "white"] if kw in desc_lower), None)
+        else:
+            color_value = color_m.group(1)
+        if not size_value or not color_value:
             continue
-        size = size_m.group(1).replace(" ", "")
-        color = color_m.group(1).lower()
+        size = size_value.replace(" ", "")
+        color = color_value.lower()
         for pat, repl in SIZE_FIXES.items():
             size = re.sub(pat, repl, size, flags=re.I)
         color = COLOR_FIXES.get(color, color)
@@ -142,6 +153,14 @@ def parse_retouch(lines: List[str]) -> Tuple[List[Dict[str, int]], bool, Set[str
             retouch.append({"name": desc.strip(), "qty": qty})
             retouch_codes.update(codes)
     return retouch, artist_series, retouch_codes, artist_codes
+
+
+@dataclass
+class OcrLine:
+    top: float
+    bottom: float
+    mid: float
+    text: str
 
 
 @dataclass
@@ -247,11 +266,6 @@ class OCRExtractor:
             # Step 6: Validate and log results
             validated_rows = self._validate_rows(cleaned_rows, work_dir)
 
-            # Quick invariants
-            assert len(validated_rows) == 9
-            assert self.frame_counts.get('5x7', {}).get('cherry', 0) == 2
-            assert '0033' in self.retouch_codes
-
             # Performance tracking
             total_time = time.time() - start_time
             self.performance_stats['last_extraction_time'] = total_time
@@ -262,11 +276,10 @@ class OCRExtractor:
                 logger.warning(f"Extraction time {total_time:.2f}s exceeds 1.0s target")
             
             return validated_rows
-            
+
         except Exception as e:
             logger.error(f"OCR extraction failed: {e}")
-            # Fallback: return empty list with error
-            return [RowRecord(warnings=[f"Extraction failed: {e}"])]
+            raise
     
     def _validate_layout(self, screenshot_path: Path) -> bool:
         """Detect if FileMaker layout has drifted using sentinel coordinates"""
@@ -296,13 +309,13 @@ class OCRExtractor:
             logger.warning(f"Layout validation failed: {e}")
             return False
     
-    def _run_column_isolated_ocr(self, base_image: np.ndarray, work_dir: Path) -> Dict[str, List[tuple]]:
+    def _run_column_isolated_ocr(self, base_image: np.ndarray, work_dir: Path) -> Dict[str, List[OcrLine]]:
         """Run OCR on each column separately with high-DPI upscaling"""
-        results: Dict[str, List[tuple]] = {}
+        results: Dict[str, List[OcrLine]] = {}
 
         for col_name, bbox in self.column_boxes.items():
+            field = COLUMN_FIELDS.get(col_name, col_name)
             try:
-                field = COLUMN_FIELDS.get(col_name, col_name)
                 # Step 1: Crop column
                 x1, y1, x2, y2 = bbox
                 column_crop = base_image[y1:y2, x1:x2]
@@ -315,13 +328,10 @@ class OCRExtractor:
                 pil_image = Image.fromarray(processed_crop)
                 ocr_lines = win_ocr(pil_image)
 
-                lines: List[tuple] = []
+                lines: List[OcrLine] = []
                 for (y_top, y_bot), txt in ocr_lines:
-                    if field == 'qty':
-                        lines.append((y_top, y_bot, txt))
-                    else:
-                        y_mid = (y_top + y_bot) / 2
-                        lines.append((y_mid, txt))
+                    line = OcrLine(top=y_top, bottom=y_bot, mid=(y_top + y_bot) / 2, text=txt)
+                    lines.append(line)
 
                 if WINOCR_AVAILABLE and len(lines) == 0:
                     raise AssertionError(f"WinOCR returned 0 lines for {col_name}")
@@ -330,8 +340,7 @@ class OCRExtractor:
                 logger.debug("Column %s: %d lines", col_name, len(lines))
 
             except Exception as e:
-                logger.error(f"OCR failed for column {col_name}: {e}")
-                results[field] = []
+                raise RuntimeError(f"OCR failed for column {col_name}") from e
 
         return results
 
@@ -405,7 +414,7 @@ class OCRExtractor:
             logger.error(f"Windows OCR failed for {col_name}: {e}")
             return []
     
-    def _mock_ocr_result(self, col_name: str) -> List[Dict]:
+    def _mock_ocr_result(self, col_name: str) -> List[OcrLine]:
         """Mock OCR for development when winocr not available"""
         # Mock data based on the actual FileMaker screenshot
         mock_data = {
@@ -425,60 +434,108 @@ class OCRExtractor:
             "COL_IMG": ["0033", "0033", "0033", "0033", "0033, 0044, 0039", "0039, 0033, 0044", "0102", "0033", "0102"]
         }
         
-        lines = []
+        lines: List[OcrLine] = []
         if col_name in mock_data:
             for i, text in enumerate(mock_data[col_name]):
                 y_top = i * 35 + 420
                 y_bot = y_top + 30
-                lines.append({
-                    'text': text,
-                    'y_position': (y_top + y_bot) / 2,
-                    'boundingBox': [0, y_top, 0, y_top, 0, y_bot, 0, y_bot],
-                    'confidence': 95.0,
-                    'column': col_name
-                })
+                lines.append(OcrLine(top=y_top, bottom=y_bot, mid=(y_top + y_bot) / 2, text=text))
 
         return lines
     
-    def _reconstruct_rows(self, cols: Dict[str, List[tuple]]) -> List[RowRecord]:
-        """Rebuild rows anchoring on quantity column."""
+    def _reconstruct_with_anchor(self, cols: Dict[str, List[OcrLine]], qty_rows: List[OcrLine]) -> List[RowRecord]:
+        """Original reconstruction anchored on quantity column."""
 
-        if not cols:
-            return []
-
-        qty_rows = sorted(cols.get('qty', []), key=lambda t: t[0])
-        med_h = np.median([(b - t) for t, b, _ in qty_rows]) if qty_rows else 0
+        med_h = np.median([(ln.bottom - ln.top) for ln in qty_rows]) if qty_rows else 0
         tol = med_h * 0.45
 
-        def pick(col_lines: List[Tuple[float, str]], y_top: float, y_bot: float) -> str:
+        def pick(col_lines: List[OcrLine], y_top: float, y_bot: float) -> str:
             band_mid = (y_top + y_bot) / 2
             best = None
             best_d = 9999
-            for y_mid, txt in col_lines:
-                d = abs(y_mid - band_mid)
-                if d < best_d and (y_top - tol) <= y_mid <= (y_bot + tol):
-                    best = txt
+            for line in col_lines:
+                d = abs(line.mid - band_mid)
+                if d < best_d and (y_top - tol) <= line.mid <= (y_bot + tol):
+                    best = line.text
                     best_d = d
             return best.strip() if best else ""
 
         rows = []
-        for y_top, y_bot, qty_txt in qty_rows:
-            row = {
-                'qty': qty_txt.strip(),
-                'code': pick(cols.get('code', []), y_top, y_bot),
-                'desc': pick(cols.get('desc', []), y_top, y_bot),
-                'imgs': pick(cols.get('imgs', []), y_top, y_bot),
-            }
+        for ln in qty_rows:
+            row = RowRecord(
+                qty=ln.text.strip(),
+                code=pick(cols.get('code', []), ln.top, ln.bottom),
+                desc=pick(cols.get('desc', []), ln.top, ln.bottom),
+                imgs=pick(cols.get('imgs', []), ln.top, ln.bottom),
+                y_position=ln.mid,
+            )
             rows.append(row)
+        return rows
 
-        logger.debug("Line counts: %s", {k: len(v) for k, v in cols.items()})
+    def _reconstruct_rows(self, cols: Dict[str, List[OcrLine]]) -> List[RowRecord]:
+        """Rebuild rows, falling back to column-agnostic clustering when qty is sparse."""
 
+        if not cols:
+            return []
+
+        logger.info(
+            "Per-column line counts: " + ", ".join(f"{k}:{len(v)}" for k, v in cols.items())
+        )
+
+        qty_rows = sorted(cols.get('qty', []), key=lambda l: l.top)
+        if len(qty_rows) >= 5:
+            rows = self._reconstruct_with_anchor(cols, qty_rows)
+            if rows:
+                return rows
+
+        # Fallback: cluster using all column lines
+        bands: List[float] = []
+        for lines in cols.values():
+            for ln in lines:
+                bands.append(ln.mid)
+
+        if not bands:
+            raise ValueError("No OCR lines to cluster")
+
+        bands = sorted(bands)
+        tol = np.median(np.diff(bands)) * 0.6 if len(bands) > 1 else 20
+        clusters: List[Tuple[float, float]] = []
+        cur = [bands[0]]
+        for y in bands[1:]:
+            if y - cur[-1] <= tol:
+                cur.append(y)
+            else:
+                clusters.append((min(cur), max(cur)))
+                cur = [y]
+        clusters.append((min(cur), max(cur)))
+
+        def pick(col_lines: List[OcrLine], y_top: float, y_bot: float) -> str:
+            best = ""
+            best_d = 1e9
+            y_mid_band = (y_top + y_bot) / 2
+            for line in col_lines:
+                d = abs(line.mid - y_mid_band)
+                if d < best_d and y_top - tol <= line.mid <= y_bot + tol:
+                    best = line.text.strip()
+                    best_d = d
+            return best
+
+        rows = []
+        for y_top, y_bot in clusters:
+            rows.append(
+                RowRecord(
+                    qty=pick(cols.get('qty', []), y_top, y_bot),
+                    code=pick(cols.get('code', []), y_top, y_bot),
+                    desc=pick(cols.get('desc', []), y_top, y_bot),
+                    imgs=pick(cols.get('imgs', []), y_top, y_bot),
+                    y_position=(y_top + y_bot) / 2,
+                )
+            )
+
+        rows = [r for r in rows if any([r.qty, r.code, r.desc, r.imgs])]
         if len(rows) < 5:
-            raise ValueError(f"Row reconstruction failed, got {len(rows)} rows")
-
-        row_records = [RowRecord(qty=r['qty'], code=r['code'], desc=r['desc'], imgs=r['imgs']) for r in rows]
-        logger.debug("Reconstructed %d rows", len(row_records))
-        return row_records
+            raise ValueError(f"Row reconstruction still too small ({len(rows)})")
+        return rows
     
     def _clean_rows(self, rows: List[RowRecord]) -> List[RowRecord]:
         """Apply domain-aware fuzzy corrections to extracted data"""

--- a/quick_extraction_demo.py
+++ b/quick_extraction_demo.py
@@ -14,14 +14,18 @@ def demo_extraction():
     
     # Extract from screenshot
     print("🔍 Extracting from Test_Full_Screenshot.png...")
-    rows = extractor.extract_rows("Test_Full_Screenshot.png")
-    
+    try:
+        rows = extractor.extract_rows("Test_Full_Screenshot.png")
+    except Exception as e:
+        print(f"❌ OCR extraction failed: {e}")
+        return
+
     if not rows:
         print("❌ No rows extracted")
         return
-    
+
     # Get the raw extracted text
-    row = rows[0]  # First (and likely only) row from column-isolated approach
+    row = rows[0]
     
     print(f"📊 Raw Column Extractions:")
     print(f"   Code Column: '{row.code}'")

--- a/test_corrected_preview_v2_with_ocr_FIXED.py
+++ b/test_corrected_preview_v2_with_ocr_FIXED.py
@@ -264,31 +264,36 @@ def test_ocr_based_preview_fixed(screenshot_path: str):
         
         # Extract rows using our proven bounding boxes
         print(f"📸 Extracting from: {screenshot_file}")
-        rows = extractor.extract_rows(str(screenshot_file))
-        
+        try:
+            rows = extractor.extract_rows(str(screenshot_file))
+        except Exception as e:
+            print(f"❌ OCR extraction failed: {e}")
+            return False
+
         if not rows:
             print("❌ No rows extracted from OCR")
             return False
-        
+
         print("✅ OCR extraction successful:")
         print(f"   • Rows extracted: {len(rows)}")
-        
-        # Get the extracted data
-        row = rows[0]  # Our column-isolated approach gives us one big row
-        print(f"   • Product codes: '{row.code}'")
-        print(f"   • Description: '{row.desc[:100]}...'")
-        print(f"   • Images: '{row.imgs}'")
-        
-        # Step 2: Parse extracted data  
+        for i, row in enumerate(rows, 1):
+            print(f"   Row {i}: Qty:{row.qty} Code:{row.code} Imgs:{row.imgs}")
+
+        # Merge all row text for parsing
+        all_codes = " ".join(r.code for r in rows)
+        all_desc = " ".join(r.desc for r in rows)
+        all_imgs = " ".join(r.imgs for r in rows)
+
+        # Step 2: Parse extracted data
         print("\n📋 Step 2: Parsing Extracted Data")
         print("=" * 60)
         
         # Extract product codes from the code column
-        product_codes = re.findall(r'\b(\d+(?:\.\d+)?)\b', row.code)
-        product_codes = [c for c in product_codes if len(c) >= 3]  # Filter reasonable codes
-        
+        product_codes = re.findall(r'\b(\d+(?:\.\d+)?)\b', all_codes)
+        product_codes = [c for c in product_codes if len(c) >= 3]
+
         # Extract image codes from the images column and description
-        all_text = f"{row.imgs} {row.desc}"
+        all_text = f"{all_imgs} {all_desc}"
         print(f"   • OCR text for codes: '{all_text[:100]}...'")
         image_codes = extract_image_codes_from_text(all_text)
 
@@ -303,7 +308,7 @@ def test_ocr_based_preview_fixed(screenshot_path: str):
         print("\n🔄 Step 3: Mapping to Order Items")
         print("=" * 60)
         
-        order_items = map_product_codes_to_items(product_codes, image_codes, row.desc)
+        order_items = map_product_codes_to_items(product_codes, image_codes, all_desc)
         
         if not order_items:
             print("❌ No order items created")

--- a/test_production_ocr_v3.py
+++ b/test_production_ocr_v3.py
@@ -58,7 +58,11 @@ def test_production_ocr():
         
         # Extract rows using column-isolated approach
         extraction_start = time.time()
-        rows = extractor.extract_rows(screenshot_path, work_dir)
+        try:
+            rows = extractor.extract_rows(screenshot_path, work_dir)
+        except Exception as e:
+            print(f"❌ OCR extraction failed: {e}")
+            return False
         extraction_time = time.time() - extraction_start
         
         print(f"✅ Extraction completed in {extraction_time:.3f}s")


### PR DESCRIPTION
## Summary
- raise errors on failed row extraction instead of returning dummy row
- add a dataclass for OCR lines and update OCR pipeline
- fall back to column-agnostic clustering when quantity data is sparse
- relax frame parsing regex and log raw lines
- handle OCR errors in demo scripts and tests

## Testing
- `pytest -q` *(fails: ImportError for winocr and cv2)*

------
https://chatgpt.com/codex/tasks/task_e_6886f23c5ad0832d9a3dced9294f7676