### PR TITLE
Improve OCR inflating and cleanup

### DIFF
--- a/app/ocr_constants.py
+++ b/app/ocr_constants.py
@@ -1,0 +1,11 @@
+import os
+
+ROW_COUNT_DEFAULT = int(os.getenv("OCR_ROW_COUNT", 18))
+ORDER_ROI_TOP = int(os.getenv("OCR_ROI_TOP", 485))
+ORDER_ROI_BOTTOM = int(os.getenv("OCR_ROI_BOTTOM", 891))
+ORDER_ROI_LEFT = int(os.getenv("OCR_ROI_LEFT", 31))
+ORDER_ROI_RIGHT = int(os.getenv("OCR_ROI_RIGHT", 950))
+ROW_EXTRA_PAD = int(os.getenv("OCR_ROW_PAD", 0))
+
+# row_index -> (dy_top, dy_bot)
+ROW_MANUAL_OFFSETS: dict[int, tuple[int, int]] = {}

--- a/test_corrected_preview_v2_with_ocr.py
+++ b/test_corrected_preview_v2_with_ocr.py
@@ -65,14 +65,9 @@ def test_ocr_based_preview():
         
         parser = FileMakerParser(products_config)
         parsed_items = parser.parse_ocr_lines(ocr_result.lines)
-        
-        # FORCE manual extraction for better image code assignment
-        print("🔧 Using manual extraction to ensure proper image code assignment...")
-        parsed_items = manual_extract_from_ocr(ocr_result.raw_text, products_config)
-        
+
         if not parsed_items:
-            print("❌ Still no order items found. Using hardcoded fallback...")
-            return create_fallback_preview(products_config)
+            raise RuntimeError("No order items parsed from OCR. Fix OCR instead of faking.")
         
         print(f"✅ Successfully parsed {len(parsed_items)} order items:")
         for item in parsed_items:
@@ -100,19 +95,7 @@ def test_ocr_based_preview():
         existing_images = discover_images_in_dropbox(dropbox_base, image_codes)
         
         if not existing_images:
-            print("⚠️ No images found in Dropbox folder, using test images...")
-            # Fallback to test images in local directory
-            test_base = Path("C:/Users/remem/Re MEMBER Dropbox/PHOTOGRAPHY PROOFING/PHOTOGRAPHER UPLOADS (1)/Ethan/From/8017 Lab Order/Lab Order TU Only")
-            existing_images = {
-                '0033': [test_base / "_MG_0033.JPG"],
-                '0039': [test_base / "_MG_0039.JPG"], 
-                '0044': [test_base / "_MG_0044.JPG"],
-                '0102': [test_base / "_MG_0102.JPG"],
-            }
-            
-            # Filter to only existing files
-            existing_images = {code: paths for code, paths in existing_images.items() 
-                             if any(p.exists() for p in paths)}
+            raise RuntimeError("No images found for detected codes")
         
         print(f"📸 Using {len(existing_images)} images:")
         for code, paths in existing_images.items():
@@ -159,97 +142,6 @@ def test_ocr_based_preview():
         traceback.print_exc()
         return False
 
-def manual_extract_from_ocr(ocr_text: str, products_config: Dict) -> List:
-    """Manually extract order items from OCR text as fallback"""
-    print("🔧 Manually extracting order items from OCR text...")
-    
-    # Extract quantities and product codes that we can see in the OCR
-    # From the OCR we see: "1 12 1 3 1 1 3 1 1 1 001 200 570 350 810 1020.5 510.3 1013 1620 2024"
-    # And image codes: "0033 0039 0044 0102"
-    
-    # Parse quantities - the sequence after the initial "1" appears to be: 12 1 3 1 1 3 1 1 1
-    quantities_match = re.search(r'(\d+(?:\s+\d+)*)', ocr_text)
-    if quantities_match:
-        qty_numbers = [int(x) for x in quantities_match.group(1).split() if int(x) > 0]
-        # Skip the first number if it's 1 (file number), look for the actual quantities
-        if qty_numbers and qty_numbers[0] == 1 and len(qty_numbers) > 1:
-            qty_list = qty_numbers[1:]  # Skip the file number
-        else:
-            qty_list = qty_numbers
-        print(f"   • Found quantities: {qty_list}")
-    else:
-        qty_list = [12, 1, 3, 1, 1, 3, 1, 1, 1]  # Default from screenshot
-    
-    # Extract product codes - these are the product IDs from the CSV
-    product_codes = ['200', '570', '350', '810', '1020.5', '510.3', '1013', '1620', '2024']
-    
-    # Extract image codes from OCR
-    image_codes = re.findall(r'\b(0\d{3})\b', ocr_text)  # Look for 4-digit codes starting with 0
-    if not image_codes:
-        image_codes = ['0033', '0039', '0044', '0102']  # Default from screenshot
-    
-    print(f"   • Detected image codes: {image_codes}")
-    print(f"   • Product codes: {product_codes}")
-    
-    # Create items with proper image code assignment
-    items = []
-    image_idx = 0
-    
-    for i, (qty, code) in enumerate(zip(qty_list, product_codes)):
-        # Find matching product in config
-        product = None
-        for p in products_config.get('products', []):
-            if p.get('product_code') == code:
-                product = p
-                break
-        
-        if not product:
-            print(f"   ⚠️  No product config found for code {code}")
-            continue
-        
-        # Smart image code assignment based on product type
-        assigned_codes = []
-        expected_images = product.get('count_images', 1)
-        
-        if code == '200':  # Wallets - use same image repeated
-            if image_idx < len(image_codes):
-                assigned_codes = [image_codes[0]] * 8  # Wallets use same image, don't advance idx
-                print(f"   • Wallets (200): using {image_codes[0]} × 8")
-        elif code in ['1020.5', '510.3']:  # Trio composites - need 3 different images
-            if len(image_codes) >= 3:
-                assigned_codes = image_codes[:3]  # Use first 3 for trio
-                print(f"   • Trio {code}: using {assigned_codes}")
-        else:  # Regular products - assign next available image
-            if image_idx < len(image_codes):
-                assigned_codes = [image_codes[image_idx]]
-                image_idx += 1
-                print(f"   • {code}: using {assigned_codes[0]}")
-            else:
-                # Fallback to first image if we run out
-                assigned_codes = [image_codes[0]] if image_codes else ['0033']
-                print(f"   • {code}: fallback to {assigned_codes[0]}")
-        
-        if not assigned_codes:
-            assigned_codes = ['0033']  # Ultimate fallback
-        
-        from app.parse import StructuredItem
-        item = StructuredItem(
-            product_slug=product.get('product_slug', f'product_{code}'),
-            quantity=int(qty),
-            width_in=product.get('width_in', 8.0),
-            height_in=product.get('height_in', 10.0),
-            orientation='portrait',
-            frame_style=product.get('frame_style_default', 'none'),
-            codes=assigned_codes,
-            source_line_text=f"{qty} {code}",
-            warnings=[],
-            count_images=expected_images,
-            multi_opening_template=product.get('multi_opening_template', None)
-        )
-        items.append(item)
-    
-    print(f"   • Created {len(items)} manual items with proper image assignments")
-    return items
 
 def extract_image_codes_from_ocr(ocr_text: str) -> List[str]:
     """Extract 4-digit image codes from OCR text"""
@@ -413,13 +305,3 @@ def determine_frame_requirements(order_items: List[Dict]) -> Dict[str, int]:
     
     return frame_requirements
 
-def create_fallback_preview(products_config: Dict) -> bool:
-    """Create preview using hardcoded data as fallback"""
-    print("🔄 Creating fallback preview with hardcoded data...")
-    
-    # Use the existing test function as fallback
-    from test_corrected_preview_v2 import test_corrected_preview_v2
-    return test_corrected_preview_v2()
-
-if __name__ == "__main__":
-    test_ocr_based_preview() 


### PR DESCRIPTION
## Summary
- inflate row crops for WinOCR with new helper `_prep_row_for_winocr`
- expose row region constants via new `ocr_constants.py`
- save extra debug files for each row
- drop manual fallback code in `test_corrected_preview_v2_with_ocr.py`

## Testing
- `pytest tests/test_ocr_mapping.py::test_mapping -q`
- `python test_corrected_preview_v2_with_ocr_FIXED.py Test_Full_Screenshot.png` *(fails: numpy.core.multiarray failed to import)*

------
https://chatgpt.com/codex/tasks/task_e_68879cdec964832dae66b8ccf0fd19f1