### PR TITLE
Improve OCR row handling and clean test fallback

### DIFF
--- a/app/ocr_constants.py
+++ b/app/ocr_constants.py
@@ -1,0 +1,17 @@
+import os
+
+# Row image inflation constants for Windows OCR
+ROW_SCALE_X = 4
+ROW_SCALE_Y = 3
+ROW_MIN_WIDTH = 1200
+ROW_SIDE_PAD = 40
+
+# Row band geometry defaults (override via environment variables)
+ROW_COUNT_DEFAULT = int(os.getenv("OCR_ROW_COUNT", 18))
+ORDER_ROI_TOP = int(os.getenv("OCR_ROI_TOP", 485))
+ORDER_ROI_BOTTOM = int(os.getenv("OCR_ROI_BOTTOM", 891))
+ORDER_ROI_LEFT = int(os.getenv("OCR_ROI_LEFT", 31))
+ORDER_ROI_RIGHT = int(os.getenv("OCR_ROI_RIGHT", 950))
+ROW_EXTRA_PAD = int(os.getenv("OCR_ROW_PAD", 0))
+# row_index -> (dy_top, dy_bot)
+ROW_MANUAL_OFFSETS: dict[int, tuple[int, int]] = {}

--- a/app/ocr_extractor.py
+++ b/app/ocr_extractor.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 from dataclasses import dataclass
 from loguru import logger
+from PIL import Image, ImageOps
 
 try:
     import winocr
@@ -75,23 +76,19 @@ FRAMES_TABLE = (953, 593, 1385, 700)
 RETOUCH_BOX = (1250, 250, 1370, 380)
 
 # ---- Tunable row grid constants ----
-ROW_COUNT_DEFAULT = 18
-ORDER_ROI_TOP = 485
-ORDER_ROI_BOTTOM = 891
-ORDER_ROI_LEFT = 31
-ORDER_ROI_RIGHT = 950
-ROW_EXTRA_PAD = 0
-# row_index -> (dy_top, dy_bot)
-ROW_MANUAL_OFFSETS: dict[int, tuple[int, int]] = {}
-
-# Optional: allow overriding from env for quick tweaking
-import os
-ROW_COUNT_DEFAULT = int(os.getenv("OCR_ROW_COUNT", ROW_COUNT_DEFAULT))
-ORDER_ROI_TOP = int(os.getenv("OCR_ROI_TOP", ORDER_ROI_TOP))
-ORDER_ROI_BOTTOM = int(os.getenv("OCR_ROI_BOTTOM", ORDER_ROI_BOTTOM))
-ORDER_ROI_LEFT = int(os.getenv("OCR_ROI_LEFT", ORDER_ROI_LEFT))
-ORDER_ROI_RIGHT = int(os.getenv("OCR_ROI_RIGHT", ORDER_ROI_RIGHT))
-ROW_EXTRA_PAD = int(os.getenv("OCR_ROW_PAD", ROW_EXTRA_PAD))
+from .ocr_constants import (
+    ROW_SCALE_X,
+    ROW_SCALE_Y,
+    ROW_MIN_WIDTH,
+    ROW_SIDE_PAD,
+    ROW_COUNT_DEFAULT,
+    ORDER_ROI_TOP,
+    ORDER_ROI_BOTTOM,
+    ORDER_ROI_LEFT,
+    ORDER_ROI_RIGHT,
+    ROW_EXTRA_PAD,
+    ROW_MANUAL_OFFSETS,
+)
 
 
 def build_row_bboxes(img_w: int, img_h: int) -> List[tuple[int, int, int, int]]:
@@ -111,6 +108,17 @@ def build_row_bboxes(img_w: int, img_h: int) -> List[tuple[int, int, int, int]]:
         y2 = min(img_h, y2 + dy_b + ROW_EXTRA_PAD)
         out.append((x1, y1, x2, y2))
     return out
+
+
+def _prep_row_for_winocr(pil_crop: Image.Image) -> Image.Image:
+    """Upscale and pad a row image before passing to Windows OCR."""
+    w, h = pil_crop.size
+    new_w = max(int(w * ROW_SCALE_X), ROW_MIN_WIDTH)
+    new_h = int(h * ROW_SCALE_Y)
+    big = pil_crop.resize((int(w * ROW_SCALE_X), new_h), Image.BICUBIC)
+    canvas = Image.new("RGB", (new_w + ROW_SIDE_PAD * 2, new_h + 8), "white")
+    canvas.paste(big, (ROW_SIDE_PAD, 4))
+    return canvas
 
 
 # Regular expression patterns for parsing the extra tables
@@ -459,11 +467,21 @@ class OCRExtractor:
 
         for idx, (x1, y1, x2, y2) in enumerate(boxes):
             crop = img.crop((x1, y1, x2, y2))
-            ocr_lines = win_ocr(crop)
-            raw = " ".join(t for (_, t) in sorted(ocr_lines, key=lambda t: t[0][0])).strip()
-            raw = re.sub(r"\s{2,}", " ", raw)
+            inflated = _prep_row_for_winocr(crop)
+            ocr_lines = win_ocr(inflated)
+            raw_lines = [t for (_, t) in sorted(ocr_lines, key=lambda t: t[0][0])]
+            raw = " ".join(raw_lines).strip()
+            if not raw:
+                # Try again with a binarized image
+                bw = ImageOps.grayscale(inflated).point(lambda x: 0 if x < 128 else 255, mode="1")
+                ocr_lines = win_ocr(bw.convert("RGB"))
+                raw_lines = [t for (_, t) in sorted(ocr_lines, key=lambda t: t[0][0])]
+                raw = " ".join(raw_lines).strip()
 
             crop.save(debug_dir / f"row_{idx:02d}.png")
+            inflated.save(debug_dir / f"row_{idx:02d}_big.png")
+            with open(debug_dir / f"row_{idx:02d}_raw.txt", "w", encoding="utf-8") as f:
+                f.write("\n".join(raw_lines) or "<EMPTY>")
             with open(debug_dir / f"row_{idx:02d}.txt", "w", encoding="utf-8") as f:
                 f.write(raw or "<EMPTY>")
 

--- a/test_corrected_preview_v2_with_ocr.py
+++ b/test_corrected_preview_v2_with_ocr.py
@@ -65,14 +65,8 @@ def test_ocr_based_preview():
         
         parser = FileMakerParser(products_config)
         parsed_items = parser.parse_ocr_lines(ocr_result.lines)
-        
-        # FORCE manual extraction for better image code assignment
-        print("🔧 Using manual extraction to ensure proper image code assignment...")
-        parsed_items = manual_extract_from_ocr(ocr_result.raw_text, products_config)
-        
         if not parsed_items:
-            print("❌ Still no order items found. Using hardcoded fallback...")
-            return create_fallback_preview(products_config)
+            raise RuntimeError("No order items parsed from OCR. Fix OCR instead of faking.")
         
         print(f"✅ Successfully parsed {len(parsed_items)} order items:")
         for item in parsed_items:
@@ -98,21 +92,9 @@ def test_ocr_based_preview():
         
         # Search for images
         existing_images = discover_images_in_dropbox(dropbox_base, image_codes)
-        
+
         if not existing_images:
-            print("⚠️ No images found in Dropbox folder, using test images...")
-            # Fallback to test images in local directory
-            test_base = Path("C:/Users/remem/Re MEMBER Dropbox/PHOTOGRAPHY PROOFING/PHOTOGRAPHER UPLOADS (1)/Ethan/From/8017 Lab Order/Lab Order TU Only")
-            existing_images = {
-                '0033': [test_base / "_MG_0033.JPG"],
-                '0039': [test_base / "_MG_0039.JPG"], 
-                '0044': [test_base / "_MG_0044.JPG"],
-                '0102': [test_base / "_MG_0102.JPG"],
-            }
-            
-            # Filter to only existing files
-            existing_images = {code: paths for code, paths in existing_images.items() 
-                             if any(p.exists() for p in paths)}
+            raise RuntimeError("No images found for detected codes")
         
         print(f"📸 Using {len(existing_images)} images:")
         for code, paths in existing_images.items():
@@ -159,97 +141,6 @@ def test_ocr_based_preview():
         traceback.print_exc()
         return False
 
-def manual_extract_from_ocr(ocr_text: str, products_config: Dict) -> List:
-    """Manually extract order items from OCR text as fallback"""
-    print("🔧 Manually extracting order items from OCR text...")
-    
-    # Extract quantities and product codes that we can see in the OCR
-    # From the OCR we see: "1 12 1 3 1 1 3 1 1 1 001 200 570 350 810 1020.5 510.3 1013 1620 2024"
-    # And image codes: "0033 0039 0044 0102"
-    
-    # Parse quantities - the sequence after the initial "1" appears to be: 12 1 3 1 1 3 1 1 1
-    quantities_match = re.search(r'(\d+(?:\s+\d+)*)', ocr_text)
-    if quantities_match:
-        qty_numbers = [int(x) for x in quantities_match.group(1).split() if int(x) > 0]
-        # Skip the first number if it's 1 (file number), look for the actual quantities
-        if qty_numbers and qty_numbers[0] == 1 and len(qty_numbers) > 1:
-            qty_list = qty_numbers[1:]  # Skip the file number
-        else:
-            qty_list = qty_numbers
-        print(f"   • Found quantities: {qty_list}")
-    else:
-        qty_list = [12, 1, 3, 1, 1, 3, 1, 1, 1]  # Default from screenshot
-    
-    # Extract product codes - these are the product IDs from the CSV
-    product_codes = ['200', '570', '350', '810', '1020.5', '510.3', '1013', '1620', '2024']
-    
-    # Extract image codes from OCR
-    image_codes = re.findall(r'\b(0\d{3})\b', ocr_text)  # Look for 4-digit codes starting with 0
-    if not image_codes:
-        image_codes = ['0033', '0039', '0044', '0102']  # Default from screenshot
-    
-    print(f"   • Detected image codes: {image_codes}")
-    print(f"   • Product codes: {product_codes}")
-    
-    # Create items with proper image code assignment
-    items = []
-    image_idx = 0
-    
-    for i, (qty, code) in enumerate(zip(qty_list, product_codes)):
-        # Find matching product in config
-        product = None
-        for p in products_config.get('products', []):
-            if p.get('product_code') == code:
-                product = p
-                break
-        
-        if not product:
-            print(f"   ⚠️  No product config found for code {code}")
-            continue
-        
-        # Smart image code assignment based on product type
-        assigned_codes = []
-        expected_images = product.get('count_images', 1)
-        
-        if code == '200':  # Wallets - use same image repeated
-            if image_idx < len(image_codes):
-                assigned_codes = [image_codes[0]] * 8  # Wallets use same image, don't advance idx
-                print(f"   • Wallets (200): using {image_codes[0]} × 8")
-        elif code in ['1020.5', '510.3']:  # Trio composites - need 3 different images
-            if len(image_codes) >= 3:
-                assigned_codes = image_codes[:3]  # Use first 3 for trio
-                print(f"   • Trio {code}: using {assigned_codes}")
-        else:  # Regular products - assign next available image
-            if image_idx < len(image_codes):
-                assigned_codes = [image_codes[image_idx]]
-                image_idx += 1
-                print(f"   • {code}: using {assigned_codes[0]}")
-            else:
-                # Fallback to first image if we run out
-                assigned_codes = [image_codes[0]] if image_codes else ['0033']
-                print(f"   • {code}: fallback to {assigned_codes[0]}")
-        
-        if not assigned_codes:
-            assigned_codes = ['0033']  # Ultimate fallback
-        
-        from app.parse import StructuredItem
-        item = StructuredItem(
-            product_slug=product.get('product_slug', f'product_{code}'),
-            quantity=int(qty),
-            width_in=product.get('width_in', 8.0),
-            height_in=product.get('height_in', 10.0),
-            orientation='portrait',
-            frame_style=product.get('frame_style_default', 'none'),
-            codes=assigned_codes,
-            source_line_text=f"{qty} {code}",
-            warnings=[],
-            count_images=expected_images,
-            multi_opening_template=product.get('multi_opening_template', None)
-        )
-        items.append(item)
-    
-    print(f"   • Created {len(items)} manual items with proper image assignments")
-    return items
 
 def extract_image_codes_from_ocr(ocr_text: str) -> List[str]:
     """Extract 4-digit image codes from OCR text"""
@@ -318,9 +209,11 @@ def convert_parsed_to_preview_format(parsed_items: List) -> List[Dict]:
             'product_slug': item.product_slug,
             'product_code': product_code,
             'quantity': item.quantity,
-            'image_codes': item.codes if hasattr(item, 'codes') and item.codes else ['0033'],
+            'image_codes': item.codes if hasattr(item, 'codes') and item.codes else [],
             'display_name': item.product_slug.replace('_', ' ').title()
         }
+        if not order_item['image_codes']:
+            print(f"   ⚠️ No image codes for row {item.product_slug}")
         
         # Add size category based on product slug and product code
         product_slug_lower = item.product_slug.lower()
@@ -413,13 +306,6 @@ def determine_frame_requirements(order_items: List[Dict]) -> Dict[str, int]:
     
     return frame_requirements
 
-def create_fallback_preview(products_config: Dict) -> bool:
-    """Create preview using hardcoded data as fallback"""
-    print("🔄 Creating fallback preview with hardcoded data...")
-    
-    # Use the existing test function as fallback
-    from test_corrected_preview_v2 import test_corrected_preview_v2
-    return test_corrected_preview_v2()
 
 if __name__ == "__main__":
     test_ocr_based_preview() 


### PR DESCRIPTION
## Summary
- tune OCR row extraction constants via new `ocr_constants` module
- upscale row crops and retry OCR if needed
- log inflated row crops and raw lines
- simplify OCR-based preview test and remove fallback paths

## Testing
- `pytest tests/test_ocr_mapping.py::test_mapping -q`
- `python test_corrected_preview_v2_with_ocr_FIXED.py Test_Full_Screenshot.png` *(fails: libGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879cdec964832dae66b8ccf0fd19f1