### PR TITLE
Improve OCR pipeline

### DIFF
--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -20,9 +20,10 @@ def expand_row_to_items(row: Dict, products_cfg: Dict[str, Dict]) -> List[Dict]:
             "product_code": code,
             "product_name": spec.get("name", code),
             "display_name": spec.get("display_name", spec.get("name", code)),
-            "size": spec.get("size", ""),
-            "size_category": spec.get("size_category", spec.get("category", "")),
-            "category": spec.get("category", ""),
+            # generator uses .size and .category to group
+            "size": spec.get("size") or spec.get("dimensions", ""),
+            "size_category": spec.get("size_category") or spec.get("category", ""),
+            "category": spec.get("category") or spec.get("size_category", ""),
             "images": imgs.copy(),
             "frame_eligible": spec.get("frame_eligible", spec.get("category") in ("print", "large_print")),
             "frame_qty": spec.get("frame_qty", 1),


### PR DESCRIPTION
## Summary
- adjust row inflation for Windows OCR
- capture full-pass OCR debug boxes
- keep categories and sizes when expanding rows
- refine image code regex
- filter items with missing images in manual test
- simplify frame requirement calc

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6887aa1d58f8832d8df8396d64347cff