### PR TITLE
Improve TSV order handling

### DIFF
--- a/app/fm_dump_parser.py
+++ b/app/fm_dump_parser.py
@@ -6,27 +6,27 @@ import json
 from pathlib import Path
 
 @dataclass
-class Row:
+class RowTSV:
+    idx: int
     qty: Optional[int]
     code: Optional[str]
-    desc: str
+    desc: Optional[str]
     imgs: List[str]
     artist_series: Optional[str]
 
 @dataclass
-class Frame:
-    number: str
+class FrameReq:
+    frame_no: str
     qty: int
     desc: str
 
 @dataclass
 class ParsedOrder:
-    rows: List[Row]
-    frames: List[Frame]
-    retouch_images: List[str]
-    directory_pose_order: Optional[str]
-    directory_pose_image: Optional[str]
-    artist_series_flags: Dict[int, str]
+    rows: List[RowTSV]
+    frames: List[FrameReq]
+    retouch_imgs: List[str]
+    directory_pose_no: Optional[str]
+    directory_pose_img: Optional[str]
 
 
 def _to_int(val: str) -> Optional[int]:
@@ -62,16 +62,15 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
                 break
     retouch_images = [v for v in retouch_images if v]
 
-    frames: List[Frame] = []
+    frames: List[FrameReq] = []
     for i in range(1,7):
         num = by_label.get(f'Frame# F{i}', '').strip()
         qty = _to_int(by_label.get(f'Frame Qty F{i}', '').strip()) or 0
         desc = by_label.get(f'Frame Desc F{i}', '').strip()
         if num or desc or qty:
-            frames.append(Frame(num, qty, desc))
+            frames.append(FrameReq(frame_no=num, qty=qty, desc=desc))
 
-    order_rows: List[Row] = []
-    artist_flags: Dict[int, str] = {}
+    order_rows: List[RowTSV] = []
     for i in range(1,19):
         qty = _to_int(by_label.get(f'Qty R{i}', '').strip())
         code = by_label.get(f'Prod R{i}', '').strip() or None
@@ -80,17 +79,14 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
         artist = by_label.get(f'Artist Series R{i}', '').strip() or None
         if not any([qty, code, desc, imgs, artist]):
             continue
-        if artist:
-            artist_flags[i] = artist
-        order_rows.append(Row(qty, code, desc, imgs, artist))
+        order_rows.append(RowTSV(idx=i, qty=qty, code=code, desc=desc or None, imgs=imgs, artist_series=artist))
 
     parsed = ParsedOrder(
         rows=order_rows,
         frames=frames,
-        retouch_images=retouch_images,
-        directory_pose_order=by_label.get('Directory Pose Order #', '').strip() or None,
-        directory_pose_image=by_label.get('Directory Pose Image #', '').strip() or None,
-        artist_series_flags=artist_flags
+        retouch_imgs=retouch_images,
+        directory_pose_no=by_label.get('Directory Pose Order #', '').strip() or None,
+        directory_pose_img=by_label.get('Directory Pose Image #', '').strip() or None,
     )
     try:
         tmp = Path('tmp')

--- a/app/order_from_tsv.py
+++ b/app/order_from_tsv.py
@@ -1,0 +1,149 @@
+from typing import List, Dict
+
+from .fm_dump_parser import RowTSV, FrameReq
+from .order_utils import apply_frames_to_items, frames_to_counts
+
+# Product metadata mapping based on POINTS SHEET & CODES.csv
+# Only the subset relevant for preview generation is included.
+PRODUCTS: Dict[str, Dict] = {
+    "001": {"type": "complimentary_8x10", "finish": "BASIC"},
+    "002": {"type": "complimentary_8x10", "finish": "PRESTIGE"},
+    "003": {"type": "complimentary_8x10", "finish": "KEEPSAKE"},
+    "200": {"type": "wallet_sheet", "finish": "BASIC"},
+    "350": {"type": "3x5_sheet", "finish": "BASIC"},
+    "510": {"type": "trio_5x10", "mat": "creme", "frame": "cherry"},
+    "510.1": {"type": "trio_5x10", "mat": "white", "frame": "cherry"},
+    "510.2": {"type": "trio_5x10", "mat": "gray", "frame": "cherry"},
+    "510.3": {"type": "trio_5x10", "mat": "black", "frame": "cherry"},
+    "511": {"type": "trio_5x10", "mat": "creme", "frame": "black"},
+    "511.1": {"type": "trio_5x10", "mat": "white", "frame": "black"},
+    "511.2": {"type": "trio_5x10", "mat": "gray", "frame": "black"},
+    "511.3": {"type": "trio_5x10", "mat": "black", "frame": "black"},
+    "570": {"type": "5x7_pair", "finish": "BASIC"},
+    "571": {"type": "5x7_pair", "finish": "PRESTIGE"},
+    "572": {"type": "5x7_pair", "finish": "KEEPSAKE"},
+    "810": {"type": "8x10", "finish": "BASIC"},
+    "811": {"type": "8x10", "finish": "PRESTIGE"},
+    "812": {"type": "8x10", "finish": "KEEPSAKE"},
+    "9111": {"type": "complimentary_8x10", "finish": "BASIC"},
+    "9112": {"type": "complimentary_8x10", "finish": "PRESTIGE"},
+    "9113": {"type": "complimentary_8x10", "finish": "KEEPSAKE"},
+    "1013": {"type": "10x13", "finish": "BASIC"},
+    "1014": {"type": "10x13", "finish": "PRESTIGE"},
+    "1015": {"type": "10x13", "finish": "KEEPSAKE"},
+    "1020": {"type": "trio_10x20", "mat": "white", "frame": "black"},
+    "1020.1": {"type": "trio_10x20", "mat": "white", "frame": "cherry"},
+    "1020.2": {"type": "trio_10x20", "mat": "gray", "frame": "black"},
+    "1020.3": {"type": "trio_10x20", "mat": "gray", "frame": "cherry"},
+    "1020.4": {"type": "trio_10x20", "mat": "black", "frame": "black"},
+    "1020.5": {"type": "trio_10x20", "mat": "black", "frame": "cherry"},
+    "1020.6": {"type": "trio_10x20", "mat": "creme", "frame": "black"},
+    "1020.7": {"type": "trio_10x20", "mat": "creme", "frame": "cherry"},
+    "1620": {"type": "16x20", "finish": "BASIC"},
+    "1621": {"type": "16x20", "finish": "PRESTIGE"},
+    "1622": {"type": "16x20", "finish": "KEEPSAKE"},
+    "2024": {"type": "20x24", "finish": "BASIC"},
+    "2025": {"type": "20x24", "finish": "PRESTIGE"},
+    "2026": {"type": "20x24", "finish": "KEEPSAKE"},
+}
+
+
+def _sort_large_print(items: List[Dict]) -> List[Dict]:
+    normal = [i for i in items if not i.get("complimentary")]
+    comp = [i for i in items if i.get("complimentary")]
+    return normal + comp
+
+
+def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg: Dict, retouch_imgs: List[str]) -> List[Dict]:
+    """Convert TSV rows to order item dictionaries."""
+    items: List[Dict] = []
+    retouch_set = set(retouch_imgs or [])
+
+    for row in rows:
+        if not row.code:
+            continue
+        meta = PRODUCTS.get(row.code)
+        if not meta:
+            continue
+        qty = row.qty or 1
+        for _ in range(qty):
+            base = {
+                "product_code": row.code,
+                "image_codes": row.imgs[:],
+                "quantity": 1,
+                "retouch": any(img in retouch_set for img in row.imgs),
+                "artist_series": bool(row.artist_series),
+                "finish": meta.get("finish", "BASIC"),
+            }
+            t = meta["type"]
+            if t.startswith("trio_"):
+                size = t.split("_")[1]
+                imgs = (row.imgs + ["", "", ""])[:3]
+                item = {
+                    **base,
+                    "product_slug": f"trio_{size}_composite",
+                    "size_category": "trio_composite",
+                    "template": "trio_horizontal",
+                    "count_images": 3,
+                    "image_codes": imgs,
+                    "frame_color": meta.get("frame", ""),
+                    "matte_color": meta.get("mat", ""),
+                    "display_name": f"Trio {size} ({meta.get('frame','')})",
+                }
+                items.append(item)
+            elif t == "wallet_sheet":
+                item = {
+                    **base,
+                    "product_slug": "200_sheet",
+                    "size_category": "wallet_sheet",
+                    "sheet_type": "2x2",
+                    "display_name": "Wallet Sheet",
+                }
+                items.append(item)
+            elif t == "3x5_sheet":
+                item = {
+                    **base,
+                    "product_slug": "350_sheet",
+                    "size_category": "small_sheet",
+                    "sheet_type": "2x2",
+                    "display_name": "3.5x5 Sheet",
+                }
+                items.append(item)
+            elif t == "5x7_pair":
+                item = {
+                    **base,
+                    "product_slug": "570_sheet",
+                    "size_category": "medium_sheet",
+                    "sheet_type": "landscape_2x1",
+                    "display_name": "5x7 Pair",
+                }
+                items.append(item)
+            elif t == "complimentary_8x10":
+                item = {
+                    **base,
+                    "product_slug": f"8x10_{base['finish'].lower()}_{row.code}",
+                    "size_category": "large",
+                    "complimentary": True,
+                    "display_name": "Complimentary 8x10",
+                }
+                items.append(item)
+            else:
+                # Large prints
+                size = t
+                item = {
+                    **base,
+                    "product_slug": f"{size}_{base['finish'].lower()}_{row.code}",
+                    "size_category": "large",
+                    "display_name": f"{size} {base['finish'].title()}",
+                }
+                items.append(item)
+
+    # apply frames
+    counts = frames_to_counts(frames)
+    apply_frames_to_items(items, counts)
+
+    # ensure complimentary last in large print section
+    large = [i for i in items if i.get("size_category") == "large"]
+    others = [i for i in items if i.get("size_category") != "large"]
+    sorted_large = _sort_large_print(large)
+    return others + sorted_large

--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 import re
 
-from .fm_dump_parser import Row, Frame
+from .fm_dump_parser import RowTSV as Row, FrameReq as Frame
 
 
 def expand_row_to_items(row: Dict, products_cfg: Dict[str, Dict]) -> List[Dict]:

--- a/test_corrected_preview_v2_with_ocr_FIXED.py
+++ b/test_corrected_preview_v2_with_ocr_FIXED.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 import re
 from typing import Dict, List
+from app.order_from_tsv import rows_to_order_items
 
 # Add app directory to path
 sys.path.insert(0, str(Path(__file__).parent))

--- a/test_preview_with_fm_dump.py
+++ b/test_preview_with_fm_dump.py
@@ -13,9 +13,9 @@ from app.config import load_product_config, load_config
 from app.image_search import create_image_searcher
 from app.enhanced_preview import EnhancedPortraitPreviewGenerator
 from test_corrected_preview_v2_with_ocr_FIXED import (
-    map_product_codes_to_items,
     determine_frame_requirements_from_items,
 )
+from app.order_from_tsv import rows_to_order_items
 
 
 def run_preview(tsv_path: str = "fm_dump.tsv") -> bool:
@@ -28,10 +28,9 @@ def run_preview(tsv_path: str = "fm_dump.tsv") -> bool:
 
     product_codes = [r.code for r in rows if r.code]
     image_codes = [c for r in rows for c in r.imgs]
-    all_desc = " ".join(r.desc or "" for r in rows)
 
-    print("\n🔄 Step 2: Map TSV rows with existing product mapping")
-    order_items = map_product_codes_to_items(product_codes, image_codes, all_desc)
+    print("\n🔄 Step 2: Convert rows to order items")
+    order_items = rows_to_order_items(rows, parsed.frames, products_cfg, parsed.retouch_imgs)
     print(f"✅ Created {len(order_items)} order items")
 
     cfg = load_config()


### PR DESCRIPTION
## Summary
- update fm_dump_parser dataclasses with index and rename fields
- add dedicated order_from_tsv module for mapping TSV rows to order items
- integrate new module into fm_dump preview
- minor import tweaks

## Testing
- `python -m py_compile app/fm_dump_parser.py app/order_from_tsv.py test_preview_with_fm_dump.py test_corrected_preview_v2_with_ocr_FIXED.py`

------
https://chatgpt.com/codex/tasks/task_e_6887de867b0c832da6ec99ac014d3bd6