### PR TITLE
Fix mapping for preview generator

### DIFF
--- a/app/fm_dump_parser.py
+++ b/app/fm_dump_parser.py
@@ -40,7 +40,7 @@ def _split_imgs(val: str) -> List[str]:
     if not val:
         return []
     parts = re.split(r'[\s,]+', val)
-    return [p for p in parts if p]
+    return [p.zfill(4) for p in parts if p]
 
 
 def parse_fm_dump(tsv_path: str) -> ParsedOrder:


### PR DESCRIPTION
## Summary
- normalize image codes in `fm_dump_parser`
- map TSV rows to generator-friendly groups in `order_from_tsv`

## Testing
- `pytest -q` *(fails: ImportError libGL.so.1 and winocr missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887e4fc6740832dadff55dccc78e1f7