### PR TITLE
Improve mapping and frame handling

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Optional, Tuple
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 from loguru import logger
 import math
+import re
 
 # Import trio composite functionality
 from .trio_composite import TrioCompositeGenerator, is_trio_product
@@ -1141,21 +1142,21 @@ class EnhancedPortraitPreviewGenerator:
                         customer_images.append(None)
             
             # Extract trio details
-            frame_color = item.get('frame_color', 'Black')
-            matte_color = item.get('matte_color', 'White')
-            
-            # FIX: Always use "5x10" for file lookup - larger composites just scale the same base file
-            # All composite files are named "5x10" regardless of target size
-            base_size = "5x10"
-            
-            logger.debug(f"Generating composite: {base_size}, frame={frame_color}, matte={matte_color}")
-            
-            # Generate the composite using the base size for file lookup
+            frame_color = item.get('frame_color', 'black').capitalize()
+            matte_color = item.get('matte_color', 'white').capitalize()
+
+            size_label = "5x10"
+            m = re.search(r'trio_(\d+x\d+)_', item.get('product_slug', ''))
+            if m:
+                size_label = m.group(1)
+
+            logger.debug(f"Generating composite: {size_label}, frame={frame_color}, matte={matte_color}")
+
             composite_image = self.trio_generator.create_composite(
                 customer_images=customer_images,
                 frame_color=frame_color,
                 matte_color=matte_color,
-                size=base_size  # Always use "5x10" for file lookup
+                size=size_label
             )
             
             if composite_image:

--- a/app/order_from_tsv.py
+++ b/app/order_from_tsv.py
@@ -1,7 +1,21 @@
 from typing import List, Dict
 
 from .fm_dump_parser import RowTSV, FrameReq
-from .order_utils import apply_frames_to_items, frames_to_counts
+from .order_utils import apply_frames_to_items_from_meta
+
+# --- Frame metadata ---
+FRAME_META = {
+    "229": {"size": "5x7",   "color": "cherry"},
+    "230": {"size": "5x7",   "color": "black"},
+    "231": {"size": "8x10",  "color": "cherry"},
+    "232": {"size": "8x10",  "color": "black"},
+    "233": {"size": "10x13", "color": "cherry"},
+    "234": {"size": "10x13", "color": "black"},
+    "235": {"size": "16x20", "color": "cherry"},
+    "236": {"size": "16x20", "color": "black"},
+    "237": {"size": "20x24", "color": "cherry"},
+    "238": {"size": "20x24", "color": "black"},
+}
 
 # Product metadata mapping based on POINTS SHEET & CODES.csv
 # Only the subset relevant for preview generation is included.
@@ -101,7 +115,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "size_category": "wallet_sheet",
                     "group_hint": "WALLET8",
                     "sheet_type": "2x2",
-                    "display_name": "Wallet Sheet",
+                    "display_name": f"Wallet Sheet ({base['finish'].title()})",
                 }
                 items.append(item)
             elif t == "3x5_sheet":
@@ -112,7 +126,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "size_category": "small_sheet",
                     "group_hint": "SHEET3x5",
                     "sheet_type": "2x2",
-                    "display_name": "3.5x5 Sheet",
+                    "display_name": f"3.5x5 Sheet ({base['finish'].title()})",
                 }
                 items.append(item)
             elif t == "5x7_pair":
@@ -123,7 +137,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "size_category": "medium_sheet",
                     "group_hint": "ALL_5x7",
                     "sheet_type": "landscape_2x1",
-                    "display_name": "5x7 Pair",
+                    "display_name": f"5x7 Pair ({base['finish'].title()})",
                 }
                 items.append(item)
             elif t == "complimentary_8x10":
@@ -132,7 +146,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "product_slug": f"8x10_{base['finish'].lower()}_{row.code}",
                     "size_category": "large_print",
                     "complimentary": True,
-                    "display_name": "Complimentary 8x10",
+                    "display_name": f"Complimentary 8x10 ({base['finish'].title()})",
                 }
                 items.append(item)
             else:
@@ -146,9 +160,8 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                 }
                 items.append(item)
 
-    # apply frames
-    counts = frames_to_counts(frames)
-    apply_frames_to_items(items, counts)
+    # apply frames with size/color info
+    apply_frames_to_items_from_meta(items, frames, FRAME_META)
 
     # ensure complimentary last in large print section
     large = [i for i in items if i.get("size_category") == "large_print"]

--- a/app/trio_composite.py
+++ b/app/trio_composite.py
@@ -11,6 +11,14 @@ from PIL import Image, ImageDraw
 from loguru import logger
 
 
+def trio_template_filename(size: str, frame: str, matte: str) -> str:
+    """Build the template filename used for composites."""
+    size_label = "5x10" if size == "5x10" else "10x20"
+    frame_title = frame.capitalize()
+    matte_title = matte.capitalize()
+    return f"Frame {frame_title} - {matte_title} {size_label} 3 Image.jpg"
+
+
 def is_trio_product(product: Dict) -> bool:
     """Check if a product is a trio product"""
     slug = product.get('slug', '')
@@ -92,11 +100,12 @@ class TrioComposite:
         
     def load_composite(self, composites_dir: Path) -> bool:
         """Load the composite frame image"""
-        # Build filename: "Frame [Color] - [Matte] 5x10 3 Image.jpg"
+        # Build filename based on frame/matte/size
         # Note: some files have extra spaces, so we'll try different variations
+        base_name = trio_template_filename(self.size, self.frame_color, self.matte_color)
         possible_filenames = [
-            f"Frame {self.frame_color} - {self.matte_color} {self.size} 3 Image.jpg",
-            f"Frame {self.frame_color} - {self.matte_color}  {self.size} 3 Image.jpg"  # Extra space
+            base_name,
+            base_name.replace("  ", " ")  # fallback with single spaces
         ]
         
         logger.debug(f"Looking for composite {self.frame_color}/{self.matte_color} {self.size} in {composites_dir}")


### PR DESCRIPTION
## Summary
- propagate finish labels to sheet display names
- map frame requests with color and size
- assign frames correctly to large prints
- adjust trio composite rendering

## Testing
- `python -m py_compile app/order_from_tsv.py app/order_utils.py app/enhanced_preview.py app/trio_composite.py`
- `python test_preview_with_fm_dump.py fm_dump.tsv`

------
https://chatgpt.com/codex/tasks/task_e_6887eb83b5c4832dab31bc1832560b74