### PR TITLE
Improve frame mapping and composite lookup

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -11,7 +11,7 @@ from loguru import logger
 import math
 
 # Import trio composite functionality
-from .trio_composite import TrioCompositeGenerator, is_trio_product
+from .trio_composite import TrioCompositeGenerator, is_trio_product, trio_template_filename
 
 # Import frame overlay functionality
 from .frame_overlay import (
@@ -1141,21 +1141,23 @@ class EnhancedPortraitPreviewGenerator:
                         customer_images.append(None)
             
             # Extract trio details
-            frame_color = item.get('frame_color', 'Black')
-            matte_color = item.get('matte_color', 'White')
-            
-            # FIX: Always use "5x10" for file lookup - larger composites just scale the same base file
-            # All composite files are named "5x10" regardless of target size
-            base_size = "5x10"
-            
-            logger.debug(f"Generating composite: {base_size}, frame={frame_color}, matte={matte_color}")
-            
-            # Generate the composite using the base size for file lookup
+            frame_color = item.get('frame_color', 'Black').capitalize()
+            matte_color = item.get('matte_color', 'White').capitalize()
+
+            # Determine composite size from product code
+            size_label = "10x20" if "1020" in item.get('product_code', '') else "5x10"
+
+            template_name = trio_template_filename(size_label, frame_color, matte_color)
+            logger.debug(
+                f"Generating composite: {template_name}"
+            )
+
+            # Generate the composite using the correct size for file lookup
             composite_image = self.trio_generator.create_composite(
                 customer_images=customer_images,
                 frame_color=frame_color,
                 matte_color=matte_color,
-                size=base_size  # Always use "5x10" for file lookup
+                size=size_label
             )
             
             if composite_image:

--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -105,3 +105,47 @@ def frames_to_counts(frames: List[Frame]) -> Dict[str, Dict[str, int]]:
         counts.setdefault(size, {}).setdefault(color, 0)
         counts[size][color] += fr.qty
     return counts
+
+
+def _extract_size_from_item(item: Dict) -> str | None:
+    """Return size like '8x10' from item fields if possible."""
+    ps = item.get("product_slug", "")
+    m = re.search(r"(\d+x\d+)", ps)
+    if m:
+        return m.group(1)
+    dn = item.get("display_name", "")
+    m = re.search(r"(\d+x\d+)", dn)
+    if m:
+        return m.group(1)
+    return None
+
+
+def apply_frames_to_items_from_meta(items: List[Dict], frame_reqs: List[Frame], meta: Dict[str, Dict[str, str]]):
+    """Assign frames to items based on frame metadata."""
+    size_buckets: Dict[str, List[Dict]] = {}
+    for it in items:
+        if it.get("size_category") != "large_print":
+            continue
+        if it.get("frame_color"):
+            continue
+        size = _extract_size_from_item(it)
+        if not size:
+            continue
+        size_buckets.setdefault(size, []).append(it)
+
+    for fr in frame_reqs:
+        info = meta.get(fr.frame_no)
+        if not info:
+            continue
+        needed = fr.qty or 0
+        bucket = size_buckets.get(info["size"], [])
+        for it in bucket:
+            if needed <= 0:
+                break
+            if not it.get("frame_color"):
+                it["frame_color"] = info["color"]
+                it["framed"] = True
+                needed -= 1
+        fr.qty = needed
+
+    return items

--- a/app/trio_composite.py
+++ b/app/trio_composite.py
@@ -11,6 +11,14 @@ from PIL import Image, ImageDraw
 from loguru import logger
 
 
+def trio_template_filename(size: str, frame: str, matte: str) -> str:
+    """Return composite filename based on parameters."""
+    size_label = "5x10" if size == "5x10" else "10x20"
+    frame_title = frame.capitalize()
+    matte_title = matte.capitalize()
+    return f"Frame {frame_title} - {matte_title} {size_label} 3 Image.jpg"
+
+
 def is_trio_product(product: Dict) -> bool:
     """Check if a product is a trio product"""
     slug = product.get('slug', '')


### PR DESCRIPTION
## Summary
- map frame metadata for each frame product
- include finish in display names for wallet sheets, 3.5x5 sheets and 5x7 pairs
- add artist flags on trio items and capitalize frame/matte colors
- compute composite filenames using new helper
- assign frames by size using updated order utilities

## Testing
- `python -m py_compile app/order_from_tsv.py app/order_utils.py app/trio_composite.py app/enhanced_preview.py`
- `python test_preview_with_fm_dump.py fm_dump.tsv`

------
https://chatgpt.com/codex/tasks/task_e_6887eb83b5c4832dab31bc1832560b74