### PR TITLE
Improve preview mapping with frame metadata

### DIFF
--- a/app/order_from_tsv.py
+++ b/app/order_from_tsv.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from .fm_dump_parser import RowTSV, FrameReq
-from .order_utils import apply_frames_to_items, frames_to_counts
+from .order_utils import apply_frames_to_items_from_meta
 
 # Product metadata mapping based on POINTS SHEET & CODES.csv
 # Only the subset relevant for preview generation is included.
@@ -45,6 +45,20 @@ PRODUCTS: Dict[str, Dict] = {
     "2024": {"type": "20x24", "finish": "BASIC"},
     "2025": {"type": "20x24", "finish": "PRESTIGE"},
     "2026": {"type": "20x24", "finish": "KEEPSAKE"},
+}
+
+# --- Frame metadata mapping ---
+FRAME_META = {
+    "229": {"size": "5x7", "color": "cherry"},
+    "230": {"size": "5x7", "color": "black"},
+    "231": {"size": "8x10", "color": "cherry"},
+    "232": {"size": "8x10", "color": "black"},
+    "233": {"size": "10x13", "color": "cherry"},
+    "234": {"size": "10x13", "color": "black"},
+    "235": {"size": "16x20", "color": "cherry"},
+    "236": {"size": "16x20", "color": "black"},
+    "237": {"size": "20x24", "color": "cherry"},
+    "238": {"size": "20x24", "color": "black"},
 }
 
 
@@ -101,7 +115,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "size_category": "wallet_sheet",
                     "group_hint": "WALLET8",
                     "sheet_type": "2x2",
-                    "display_name": "Wallet Sheet",
+                    "display_name": f"Wallet Sheet ({base['finish'].title()})",
                 }
                 items.append(item)
             elif t == "3x5_sheet":
@@ -112,7 +126,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "size_category": "small_sheet",
                     "group_hint": "SHEET3x5",
                     "sheet_type": "2x2",
-                    "display_name": "3.5x5 Sheet",
+                    "display_name": f"3.5x5 Sheet ({base['finish'].title()})",
                 }
                 items.append(item)
             elif t == "5x7_pair":
@@ -123,7 +137,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "size_category": "medium_sheet",
                     "group_hint": "ALL_5x7",
                     "sheet_type": "landscape_2x1",
-                    "display_name": "5x7 Pair",
+                    "display_name": f"5x7 Pair ({base['finish'].title()})",
                 }
                 items.append(item)
             elif t == "complimentary_8x10":
@@ -132,7 +146,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "product_slug": f"8x10_{base['finish'].lower()}_{row.code}",
                     "size_category": "large_print",
                     "complimentary": True,
-                    "display_name": "Complimentary 8x10",
+                    "display_name": f"Complimentary 8x10 ({base['finish'].title()})",
                 }
                 items.append(item)
             else:
@@ -147,8 +161,7 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                 items.append(item)
 
     # apply frames
-    counts = frames_to_counts(frames)
-    apply_frames_to_items(items, counts)
+    apply_frames_to_items_from_meta(items, frames, FRAME_META)
 
     # ensure complimentary last in large print section
     large = [i for i in items if i.get("size_category") == "large_print"]


### PR DESCRIPTION
## Summary
- map frame numbers to sizes & colors
- surface finish in display names for wallets, sheets, and pairs
- assign frames to matching items based on new metadata

## Testing
- `python -m py_compile app/order_from_tsv.py app/order_utils.py`
- `python test_preview_with_fm_dump.py fm_dump.tsv`

------
https://chatgpt.com/codex/tasks/task_e_6887eb83b5c4832dab31bc1832560b74