### PR TITLE
Implement complimentary 8x10 and 5x7 frame splitting

### DIFF
--- a/app/fm_dump_parser.py
+++ b/app/fm_dump_parser.py
@@ -13,12 +13,18 @@ class RowTSV:
     desc: Optional[str]
     imgs: List[str]
     artist_series: Optional[str]
+    complimentary: bool = False
 
 @dataclass
 class FrameReq:
     frame_no: str
     qty: int
     desc: str
+
+    @property
+    def number(self) -> str:
+        """Backwards compatibility alias used in tests."""
+        return self.frame_no
 
 @dataclass
 class ParsedOrder:
@@ -27,6 +33,8 @@ class ParsedOrder:
     retouch_imgs: List[str]
     directory_pose_no: Optional[str]
     directory_pose_img: Optional[str]
+    dir_pose_code: Optional[str] = None
+    dir_pose_img: Optional[str] = None
 
 
 def _to_int(val: str) -> Optional[int]:
@@ -88,6 +96,11 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
         directory_pose_no=by_label.get('Directory Pose Order #', '').strip() or None,
         directory_pose_img=by_label.get('Directory Pose Image #', '').strip() or None,
     )
+    # store raw directory pose values for downstream logic
+    dir_code = by_label.get('Directory Pose Order #', '').strip()
+    dir_img = by_label.get('Directory Pose Image #', '').strip()
+    parsed.dir_pose_code = dir_code
+    parsed.dir_pose_img = dir_img
     try:
         tmp = Path('tmp')
         tmp.mkdir(exist_ok=True)

--- a/app/order_from_tsv.py
+++ b/app/order_from_tsv.py
@@ -1,6 +1,6 @@
 from typing import List, Dict
 
-from .fm_dump_parser import RowTSV, FrameReq
+from .fm_dump_parser import RowTSV, FrameReq, ParsedOrder
 from .order_utils import apply_frames_to_items_from_meta
 
 # Product metadata mapping based on POINTS SHEET & CODES.csv
@@ -68,10 +68,71 @@ def _sort_large_print(items: List[Dict]) -> List[Dict]:
     return normal + comp
 
 
-def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg: Dict, retouch_imgs: List[str]) -> List[Dict]:
+def explode_5x7_pairs_for_frames(items: List[Dict], frame_reqs: List[FrameReq], frame_meta: Dict[str, Dict[str, str]]):
+    """Split 5x7 pair sheets into individual prints when frames are requested."""
+    needed = 0
+    for fr in frame_reqs:
+        info = frame_meta.get(fr.frame_no)
+        if info and info.get("size") == "5x7":
+            needed += fr.qty or 0
+
+    if needed == 0:
+        return items
+
+    new_items: List[Dict] = []
+    for it in items:
+        if (
+            it.get("product_slug") == "ALL_5x7"
+            and it.get("sheet_type") == "landscape_2x1"
+            and needed > 0
+        ):
+            imgs = it.get("image_codes", [])
+            used = 0
+            for i in range(2):
+                if needed <= 0:
+                    break
+                single = {
+                    **it,
+                    "product_code": "570_individual",
+                    "sheet_type": "single",
+                    "display_name": f"5x7 ({it.get('finish','').title()})",
+                    "quantity": 1,
+                    "image_codes": [imgs[0] if len(imgs) == 1 else imgs[i]],
+                    "framed": False,
+                    "frame_color": "",
+                    "has_frame": False,
+                }
+                new_items.append(single)
+                needed -= 1
+                used += 1
+            if used < 2:
+                new_items.append(it)
+        else:
+            new_items.append(it)
+
+    return new_items
+
+
+def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg: Dict, retouch_imgs: List[str], parsed: ParsedOrder | None = None) -> List[Dict]:
     """Convert TSV rows to order item dictionaries."""
     items: List[Dict] = []
     retouch_set = set(retouch_imgs or [])
+
+    # ---- complimentary 8x10 injection ----
+    if parsed and getattr(parsed, "dir_pose_code", None):
+        code = str(parsed.dir_pose_code).zfill(3)
+        if code in PRODUCTS and PRODUCTS[code].get("type") == "complimentary_8x10":
+            img_code = str(parsed.dir_pose_img or "").zfill(4)
+            comp_row = RowTSV(
+                idx=0,
+                qty=1,
+                code=code,
+                desc="Directory Pose Complimentary",
+                imgs=[img_code],
+                artist_series=False,
+                complimentary=True,
+            )
+            rows = list(rows) + [comp_row]
 
     for row in rows:
         if not row.code:
@@ -160,6 +221,9 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "display_name": f"{size} {base['finish'].title()}",
                 }
                 items.append(item)
+
+    # split 5x7 pair sheets into singles if frames are requested
+    items = explode_5x7_pairs_for_frames(items, frames, FRAME_META)
 
     # apply frames using metadata
     apply_frames_to_items_from_meta(items, frames, FRAME_META)

--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -125,8 +125,8 @@ def apply_frames_to_items_from_meta(items: List[Dict], frame_reqs: List[Frame], 
     """Assign frames to items based on frame metadata."""
     size_buckets: Dict[str, List[Dict]] = {}
     for it in items:
-        if it.get("size_category") != "large_print":
-            continue
+        if it.get("sheet_type") == "landscape_2x1":
+            continue  # skip 5x7 pair sheets
         if it.get("frame_color"):
             continue
         size = _extract_size_from_item(it)
@@ -148,6 +148,8 @@ def apply_frames_to_items_from_meta(items: List[Dict], frame_reqs: List[Frame], 
                 it["framed"] = True
                 it["has_frame"] = True
                 it["frame_spec"] = FrameSpec(info["size"], info["color"].capitalize())
+                if info["size"] == "5x7" and it.get("product_code") == "570_individual":
+                    it["product_code"] = "570_individual_framed"
                 needed -= 1
         fr.qty = needed
 

--- a/test_preview_with_fm_dump.py
+++ b/test_preview_with_fm_dump.py
@@ -30,7 +30,7 @@ def run_preview(tsv_path: str = "fm_dump.tsv") -> bool:
     image_codes = [c for r in rows for c in r.imgs]
 
     print("\n🔄 Step 2: Convert rows to order items")
-    order_items = rows_to_order_items(rows, parsed.frames, products_cfg, parsed.retouch_imgs)
+    order_items = rows_to_order_items(rows, parsed.frames, products_cfg, parsed.retouch_imgs, parsed=parsed)
     print(f"✅ Created {len(order_items)} order items")
     from pprint import pprint
     print("\n🔎 ORDER ITEM SNAPSHOT (first 15)")


### PR DESCRIPTION
## Summary
- parse directory pose info in `fm_dump_parser`
- generate complimentary 8x10 items when directory pose codes appear
- split 5x7 pair sheets into singles for framing
- assign frames to 5x7 singles
- adjust test script

## Testing
- `pytest tests/test_fm_dump_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888214554e0832da1bca6d351df9f60