### PR TITLE
Add Directory Pose complimentary prints and 5x7 frame splitting

### DIFF
--- a/app/fm_dump_parser.py
+++ b/app/fm_dump_parser.py
@@ -13,6 +13,7 @@ class RowTSV:
     desc: Optional[str]
     imgs: List[str]
     artist_series: Optional[str]
+    complimentary: bool = False
 
 @dataclass
 class FrameReq:
@@ -20,13 +21,17 @@ class FrameReq:
     qty: int
     desc: str
 
+    @property
+    def number(self) -> str:
+        return self.frame_no
+
 @dataclass
 class ParsedOrder:
     rows: List[RowTSV]
     frames: List[FrameReq]
     retouch_imgs: List[str]
-    directory_pose_no: Optional[str]
-    directory_pose_img: Optional[str]
+    dir_pose_code: Optional[str]
+    dir_pose_img: Optional[str]
 
 
 def _to_int(val: str) -> Optional[int]:
@@ -85,9 +90,14 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
         rows=order_rows,
         frames=frames,
         retouch_imgs=retouch_images,
-        directory_pose_no=by_label.get('Directory Pose Order #', '').strip() or None,
-        directory_pose_img=by_label.get('Directory Pose Image #', '').strip() or None,
+        dir_pose_code=None,
+        dir_pose_img=None,
     )
+
+    dir_code = by_label.get('Directory Pose Order #', '').strip()
+    dir_img = by_label.get('Directory Pose Image #', '').strip()
+    parsed.dir_pose_code = dir_code or None
+    parsed.dir_pose_img = dir_img or None
     try:
         tmp = Path('tmp')
         tmp.mkdir(exist_ok=True)

--- a/app/order_from_tsv.py
+++ b/app/order_from_tsv.py
@@ -68,10 +68,64 @@ def _sort_large_print(items: List[Dict]) -> List[Dict]:
     return normal + comp
 
 
-def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg: Dict, retouch_imgs: List[str]) -> List[Dict]:
+def explode_5x7_pairs_for_frames(items: List[Dict], frame_reqs: List[FrameReq], frame_meta: Dict[str, Dict[str, str]]):
+    """Split 5x7 pair sheets into singles when frames are requested."""
+    needed = 0
+    for fr in frame_reqs:
+        info = frame_meta.get(fr.frame_no)
+        if info and info.get("size") == "5x7":
+            needed += fr.qty or 0
+
+    if needed == 0:
+        return items
+
+    new_items = []
+    for it in items:
+        if (
+            it.get("product_slug") == "ALL_5x7"
+            and it.get("sheet_type") == "landscape_2x1"
+            and needed > 0
+        ):
+            imgs = it.get("image_codes", []) or ["0000"]
+            for i in range(2):
+                if needed <= 0:
+                    break
+                single = {
+                    **it,
+                    "sheet_type": "single",
+                    "display_name": f"5x7 ({it['finish'].title()})",
+                    "quantity": 1,
+                    "image_codes": [imgs[0]],
+                    "framed": False,
+                    "frame_color": "",
+                }
+                new_items.append(single)
+                needed -= 1
+        else:
+            new_items.append(it)
+    return new_items
+
+
+def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg: Dict, retouch_imgs: List[str], parsed=None) -> List[Dict]:
     """Convert TSV rows to order item dictionaries."""
     items: List[Dict] = []
     retouch_set = set(retouch_imgs or [])
+
+    # ---- complimentary 8x10 injection ----
+    if parsed is not None and getattr(parsed, "dir_pose_code", None):
+        code = str(parsed.dir_pose_code).zfill(3)
+        if code in PRODUCTS and PRODUCTS[code].get("type") == "complimentary_8x10":
+            img_code = str(parsed.dir_pose_img or "").zfill(4)
+            comp_row = RowTSV(
+                idx=0,
+                qty=1,
+                code=code,
+                desc="Directory Pose Complimentary",
+                imgs=[img_code],
+                artist_series=False,
+                complimentary=True,
+            )
+            rows.append(comp_row)
 
     for row in rows:
         if not row.code:
@@ -160,6 +214,9 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
                     "display_name": f"{size} {base['finish'].title()}",
                 }
                 items.append(item)
+
+    # split 5x7 pairs into singles if frames are requested
+    items = explode_5x7_pairs_for_frames(items, frames, FRAME_META)
 
     # apply frames using metadata
     apply_frames_to_items_from_meta(items, frames, FRAME_META)

--- a/test_preview_with_fm_dump.py
+++ b/test_preview_with_fm_dump.py
@@ -30,7 +30,7 @@ def run_preview(tsv_path: str = "fm_dump.tsv") -> bool:
     image_codes = [c for r in rows for c in r.imgs]
 
     print("\n🔄 Step 2: Convert rows to order items")
-    order_items = rows_to_order_items(rows, parsed.frames, products_cfg, parsed.retouch_imgs)
+    order_items = rows_to_order_items(rows, parsed.frames, products_cfg, parsed.retouch_imgs, parsed)
     print(f"✅ Created {len(order_items)} order items")
     from pprint import pprint
     print("\n🔎 ORDER ITEM SNAPSHOT (first 15)")


### PR DESCRIPTION
## Summary
- extend TSV parser for Directory Pose metadata
- support complimentary 8x10 generation from directory pose
- split 5×7 pair sheets into single prints when frames are ordered
- update integration test script for new API

## Testing
- `python -m pytest tests/test_fm_dump_parser.py -q`
- `python -m pytest tests -q` *(fails: module import errors and parser tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888214554e0832da1bca6d351df9f60