### PR TITLE
Fix 5x7 single frame rendering

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -1419,8 +1419,8 @@ class EnhancedPortraitPreviewGenerator:
         master_img = self.master_images[image_code]
         
         # Check if this item has a frame
-        if item and item.get('has_frame') and item.get('frame_spec'):
-            frame_spec = item.get('frame_spec')
+        if item and (item.get('has_frame') or item.get('framed')):
+            frame_spec = item.get('frame_spec') or FrameSpec("5x7", item.get('frame_color', 'Black').capitalize())
             
             # Calculate the inner image size (original container minus frame thickness)
             inner_width = width - frame_spec.left_thickness - frame_spec.right_thickness

--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -126,7 +126,7 @@ def apply_frames_to_items_from_meta(items: List[Dict], frame_reqs: List[Frame], 
     """Assign frames to items based on frame metadata."""
     size_buckets: Dict[str, List[Dict]] = {}
     for it in items:
-        if it.get("size_category") not in ("large_print", "medium_print"):
+        if it.get("size_category") != "large_print":
             continue
         if it.get("frame_color") or it.get("sheet_type") == "landscape_2x1":
             # skip already framed or 5x7 pair sheets
@@ -201,7 +201,9 @@ def normalize_5x7_for_frames(
                     continue
                 if fr.qty and fr.qty > 0:
                     s["framed"] = True
+                    s["has_frame"] = True
                     s["frame_color"] = info["color"]
+                    s["frame_spec"] = FrameSpec("5x7", info["color"].capitalize())
                     fr.qty -= 1
                     frames_needed -= 1
                     break


### PR DESCRIPTION
## Summary
- ensure 5×7 singles carry `frame_spec` and `has_frame`
- only auto-assign frames from metadata for large prints
- allow `_render_large_print` to apply frames when `framed` flag set

## Testing
- `pytest -q` *(fails: numpy.core.multiarray failed to import)*

------
https://chatgpt.com/codex/tasks/task_e_68882efae1a8832dabf454ceaf75f004