### PR TITLE
Add extreme layout test option

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ python -c "from app.config import load_config; print('Config valid!')"
 ### Asset Validation
 Run startup checks to ensure required directories and files exist.
 
+### Preview from TSV
+The `test_preview_with_fm_dump.py` helper script can render a preview from a
+FileMaker TSV export without performing OCR. Use this for debugging complex
+orders. Pass `--extreme` to replicate items and stress‑test the layout engine:
+
+```bash
+python test_preview_with_fm_dump.py --extreme
+```
+
 ## 📝 Adding New Products
 
 1. **Update `config/products.yaml`**


### PR DESCRIPTION
## Summary
- enable stress tests in `test_preview_with_fm_dump.py`
- document how to run preview generation from TSV

## Testing
- `python test_preview_with_fm_dump.py --extreme`
- `python -m pytest -q` *(fails: libGL.so.1 and winocr missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888338c5654832d97d3d4e7c07eb1a4