### PR TITLE
Fix 5x7 frame assignment and default display names

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -899,7 +899,7 @@ class EnhancedPortraitPreviewGenerator:
                     spec = self.product_specs[product_code]
                 else:
                     size_cat = item.get('size_category')
-                    name = item.get('display_name', '')
+                    name = item.get('display_name', 'Unknown')
                     if size_cat == 'large_print' or any(sz in name for sz in LARGE_PRINT_SIZES):
                         guessed_size = _extract_size_from_item(item) or '8x10'
                         width, height = {
@@ -2970,7 +2970,7 @@ class EnhancedPortraitPreviewGenerator:
     def _is_artist_series(self, item: Dict, spec: Dict) -> bool:
         """Check if item qualifies for Artist Series banner"""
         # Artist Series applies to top three portrait options with specific descriptions
-        display_name = item.get('display_name', '')
+        display_name = item.get('display_name', 'Unknown')
         product_slug = item.get('product_slug', '')
         
         # Check for artist series keywords in display name or description

--- a/app/frame_overlay.py
+++ b/app/frame_overlay.py
@@ -423,7 +423,7 @@ class FrameOverlayEngine:
                     framed_item.update({
                         'has_frame': True,
                         'frame_spec': FrameSpec(frame_size, frame_style),
-                        'display_name': f"{framed_item.get('display_name', '')} ({frame_style} Frame)"
+                        'display_name': f"{framed_item.get('display_name', 'Unknown')} ({frame_style} Frame)"
                     })
                     modified_items.append(framed_item)
                     frames_used[frame_size] += quantity
@@ -436,7 +436,7 @@ class FrameOverlayEngine:
                         'quantity': available_frames,
                         'has_frame': True,
                         'frame_spec': FrameSpec(frame_size, frame_style),
-                        'display_name': f"{framed_item.get('display_name', '')} ({frame_style} Frame)"
+                        'display_name': f"{framed_item.get('display_name', 'Unknown')} ({frame_style} Frame)"
                     })
                     modified_items.append(framed_item)
                     

--- a/app/order_from_tsv.py
+++ b/app/order_from_tsv.py
@@ -188,6 +188,9 @@ def rows_to_order_items(rows: List[RowTSV], frames: List[FrameReq], products_cfg
     # apply frames using metadata
     apply_frames_to_items_from_meta(items, frames, FRAME_META)
 
+    for item in items:
+        item.setdefault("display_name", item.get("product_name", "Unknown"))
+
     # ensure complimentary last in large print section
     large = [i for i in items if i.get("size_category") == "large_print"]
     others = [i for i in items if i.get("size_category") != "large_print"]

--- a/app/order_utils.py
+++ b/app/order_utils.py
@@ -194,19 +194,17 @@ def normalize_5x7_for_frames(
     for s in singles:
         if frames_needed <= 0:
             break
-        if not s.get("framed"):
-            for fr in frame_reqs:
-                info = frame_meta.get(fr.frame_no)
-                if not info or info.get("size") != "5x7":
-                    continue
-                if fr.qty and fr.qty > 0:
-                    s["framed"] = True
-                    s["has_frame"] = True
-                    s["frame_color"] = info["color"]
-                    s["frame_spec"] = FrameSpec("5x7", info["color"].capitalize())
-                    fr.qty -= 1
-                    frames_needed -= 1
-                    break
+        for fr in frame_reqs:
+            info = frame_meta.get(fr.frame_no)
+            if not info or info["size"] != "5x7" or (fr.qty or 0) <= 0:
+                continue
+            s["framed"] = True
+            s["has_frame"] = True
+            s["frame_color"] = info["color"]
+            s["frame_spec"] = FrameSpec("5x7", info["color"].capitalize())
+            fr.qty -= 1
+            frames_needed -= 1
+            break
 
     framed_singles = [s for s in singles if s.get("framed")]
     unframed_singles = [s for s in singles if not s.get("framed")]


### PR DESCRIPTION
## Summary
- ensure 5x7 singles get frames when requested
- provide fallback display_name for injected items
- guard against missing display_name in layout
- update framed item labels

## Testing
- `python run_tests.py --unit -v` *(fails: missing required packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68883723e734832d96dab70ffb125359