### PR TITLE
Fix layout padding and composite fallback

### DIFF
--- a/app/trio_composite.py
+++ b/app/trio_composite.py
@@ -209,6 +209,7 @@ class TrioCompositeGenerator:
             
         # Create and load composite
         composite = TrioComposite(frame_color, matte_color, size)
+        scale = 1.0
         if not composite.load_composite(self.composites_dir):
             if fallback_to_5x10 and size == "10x20":
                 logger.warning("10x20 composite not found, falling back to 5x10")
@@ -216,6 +217,7 @@ class TrioCompositeGenerator:
                 if not composite.load_composite(self.composites_dir):
                     return None
                 size = "5x10"
+                scale = 2.0
             else:
                 return None
             
@@ -261,6 +263,12 @@ class TrioCompositeGenerator:
                 logger.error(f"Failed to paste image {i+1} onto frame: {e}")
                 continue
         
+        if scale != 1.0:
+            result_image = result_image.resize(
+                (result_image.width * int(scale), result_image.height * int(scale)),
+                Image.Resampling.LANCZOS
+            )
+
         return result_image
     
     def _apply_individual_banner(self, image: Image.Image, image_path: Path) -> Image.Image:

--- a/test_preview_with_fm_dump.py
+++ b/test_preview_with_fm_dump.py
@@ -35,7 +35,7 @@ def _expand_extremes(order_items: List[dict]) -> List[dict]:
     return extreme_items
 
 
-def run_preview(tsv_path: str = "fm_dump.tsv", extreme: bool = False) -> bool:
+def run_preview(tsv_path: str = "fm_dump.tsv", extreme: bool = False, debug: bool = False) -> bool:
     products_cfg = load_product_config()
 
     print("\n🔍 Step 1: Load AHK TSV Export")
@@ -88,7 +88,7 @@ def run_preview(tsv_path: str = "fm_dump.tsv", extreme: bool = False) -> bool:
     outdir.mkdir(parents=True, exist_ok=True)
     gen = EnhancedPortraitPreviewGenerator(products_cfg, existing_images, outdir)
     out = outdir / "fm_dump_preview.png"
-    gen.generate_size_based_preview_with_composites(order_items, out, frame_requirements)
+    gen.generate_size_based_preview_with_composites(order_items, out, frame_requirements, debug=debug)
     print(f"✅ Preview saved to {out}")
     return True
 
@@ -97,6 +97,8 @@ if __name__ == "__main__":
     tsv = "fm_dump.tsv"
     extreme = False
 
+    debug = False
+
     if len(sys.argv) > 1:
         if sys.argv[1] == "--extreme":
             extreme = True
@@ -104,5 +106,7 @@ if __name__ == "__main__":
             tsv = sys.argv[1]
             if len(sys.argv) > 2 and sys.argv[2] == "--extreme":
                 extreme = True
+        if "--debug" in sys.argv:
+            debug = True
 
-    run_preview(tsv, extreme)
+    run_preview(tsv, extreme, debug)


### PR DESCRIPTION
## Summary
- compute safe padding once
- assert layout within safe zone instead of shifting
- guard spec lookup and improve logging
- account for right column in PPI calculation
- expose debug flag in preview script
- upscale trio composites when using 5x10 fallback

## Testing
- `pytest tests/test_parse.py::TestFileMakerParser::test_parse_basic_print_line -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68884085bcbc832db0e1f8048bf9e49d