### PR TITLE
Fix layout start for empty left column

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -601,6 +601,10 @@ class EnhancedPortraitPreviewGenerator:
         row_order = ['large_print', 'ALL_5x7', 'SHEET3x5', 'WALLET8']
         
         current_y = self.LEFT_Y0 + 20  # Start with small top margin
+
+        # If there are no left-column groups, anchor to the true top
+        if not any(groups.get(g) for g in row_order):
+            current_y = self.LEFT_Y0
         row_gap = 30  # Gap between rows
         
         for group_name in row_order:


### PR DESCRIPTION
## Summary
- keep left column anchored when there are no left-side groups

## Testing
- `python test_preview_with_fm_dump.py fm_dump.tsv`

------
https://chatgpt.com/codex/tasks/task_e_6888e1aa4cc8832dabb5255d460850fd