### PR TITLE
Fix composites overflow and missing directory pose image

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -1130,9 +1130,9 @@ class EnhancedPortraitPreviewGenerator:
             h_over = max_right - (self.CANVAS_W - self.safe_pad_px)
 
             # Detect missing composites (treated as overflow)
-            expected = len(groups.get('trio_composite', []))
+            n_composites = len(groups.get('trio_composite', []))
             placed = sum(1 for i in layout if i.get('is_composite'))
-            c_over = expected - placed
+            c_over = max(0, n_composites - placed)
 
             return layout, max(v_over, h_over, c_over)
 

--- a/app/fm_dump_parser.py
+++ b/app/fm_dump_parser.py
@@ -84,6 +84,21 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
             continue
         order_rows.append(RowTSV(idx=i, qty=qty, code=code, desc=desc or None, imgs=imgs, artist_series=artist))
 
+    pose_img = by_label.get('Directory Pose Image #', '').strip()
+    if pose_img:
+        pose_code = by_label.get('Directory Pose Order #', '').strip() or '002'
+        order_rows.append(
+            RowTSV(
+                idx=0,
+                qty=1,
+                code=pose_code,
+                desc='Complimentary 8x10',
+                imgs=[pose_img.zfill(4)],
+                artist_series=None,
+                complimentary=True,
+            )
+        )
+
     parsed = ParsedOrder(
         rows=order_rows,
         frames=frames,


### PR DESCRIPTION
## Summary
- avoid treating non-existent composite prints as overflow
- include directory pose image when parsing the TSV export

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q opencv-python-headless`
- `pip install -q winocr` *(failed: build wheel for winrt-runtime)*
- `pytest -q` *(errors: NotImplementedError on pygetwindow and missing winocr)*

------
https://chatgpt.com/codex/tasks/task_e_6888e5391dd0832dad40235b833ca72f