### PR TITLE
Fix duplicate complimentary 8x10 counting

### DIFF
--- a/app/fm_dump_parser.py
+++ b/app/fm_dump_parser.py
@@ -85,14 +85,20 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
         order_rows.append(RowTSV(idx=i, qty=qty, code=code, desc=desc or None, imgs=imgs, artist_series=artist))
 
     pose_img = by_label.get('Directory Pose Image #', '').strip()
+    pose_code = by_label.get('Directory Pose Order #', '').strip() or '002'
     if pose_img:
-        already_added = any(
-            r.code == (by_label.get('Directory Pose Order #', '').strip() or '002')
-            and r.complimentary
-            for r in order_rows
+        dup = next(
+            (
+                r
+                for r in order_rows
+                if r.code == pose_code and set(r.imgs) == {pose_img.zfill(4)}
+            ),
+            None,
         )
-        if not already_added:
-            pose_code = by_label.get('Directory Pose Order #', '').strip() or '002'
+        if dup:
+            dup.complimentary = True
+            dup.qty = 1
+        else:
             order_rows.append(
                 RowTSV(
                     idx=0,
@@ -104,6 +110,17 @@ def parse_fm_dump(tsv_path: str) -> ParsedOrder:
                     complimentary=True,
                 )
             )
+
+    unique = {}
+    for r in order_rows:
+        key = (r.code, tuple(r.imgs))
+        if key not in unique:
+            unique[key] = r
+        else:
+            if r.complimentary:
+                unique[key].complimentary = True
+            unique[key].qty = max(unique[key].qty or 1, r.qty or 1)
+    order_rows = list(unique.values())
 
     parsed = ParsedOrder(
         rows=order_rows,

--- a/tests/test_fm_dump_parser.py
+++ b/tests/test_fm_dump_parser.py
@@ -12,3 +12,19 @@ def test_parse_fm_dump_basic():
     assert first.code == "1013"
     assert first.imgs == ["0033"]
     assert parsed.frames[0].frame_no == "229"
+
+
+def test_complimentary_deduplicated():
+    tsv_path = Path(__file__).resolve().parents[1] / "fm_dump.tsv"
+    parsed = parse_fm_dump(str(tsv_path))
+    from app.order_from_tsv import rows_to_order_items
+    from app.config import load_product_config
+
+    products_cfg = load_product_config()
+    items = rows_to_order_items(parsed.rows, parsed.frames, products_cfg, parsed.retouch_imgs, None)
+    comp_count = sum(
+        1
+        for it in items
+        if it.get("complimentary") and "8x10" in it["display_name"]
+    )
+    assert comp_count == 1


### PR DESCRIPTION
## Summary
- mark existing row as complimentary when it matches the directory pose
- remove duplicate rows after parsing
- test that only one complimentary print exists

## Testing
- `pytest tests/test_fm_dump_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688918c033d8832d8aaf3023a6d1daaa