### PR TITLE
Fix retouch banner logic

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -3083,8 +3083,11 @@ class EnhancedPortraitPreviewGenerator:
 
     def _is_retouch(self, image_codes: List[str], item: Dict | None = None) -> bool:
         """Check if an item or its images are flagged for retouch."""
-        if item and item.get('retouch'):
-            return True
+        if item:
+            if item.get('retouch'):
+                return True
+            if any(item.get('retouch_flags', [])):
+                return True
 
         # Fallback to legacy list based on image codes
         retouch_list = ['0033', '0039']

--- a/tests/test_fm_dump_parser.py
+++ b/tests/test_fm_dump_parser.py
@@ -47,3 +47,20 @@ def test_single_complimentary_item():
     )
     comps = [it for it in items if it.get("complimentary")]
     assert len(comps) == 1
+
+
+def test_prestige_not_marked_retouch():
+    """Complimentary 8x10 in PRESTIGE finish should not set retouch flag."""
+    from app.fm_dump_parser import RowTSV, ParsedOrder
+    from app.order_from_tsv import rows_to_order_items
+    from app.config import load_product_config
+
+    row = RowTSV(idx=1, qty=1, code="002", desc="Complimentary 8x10", imgs=["0517"], artist_series=False, complimentary=True)
+    parsed = ParsedOrder(rows=[row], frames=[], retouch_imgs=[], directory_pose_no=None, directory_pose_img=None)
+
+    products_cfg = load_product_config()
+    items = rows_to_order_items(parsed.rows, parsed.frames, products_cfg, parsed.retouch_imgs, parsed)
+
+    comp = next(it for it in items if it.get("complimentary"))
+    assert comp["finish"] == "PRESTIGE"
+    assert not comp.get("retouch")


### PR DESCRIPTION
## Summary
- refine _is_retouch to consider `retouch_flags`
- add regression test for complimentary PRESTIGE 8x10

## Testing
- `pytest tests/test_fm_dump_parser.py::test_prestige_not_marked_retouch -q`

------
https://chatgpt.com/codex/tasks/task_e_68891deee308832d8dc17c1c2f7b8571