### PR TITLE
Fix overlay banner logic

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -2986,19 +2986,20 @@ class EnhancedPortraitPreviewGenerator:
             if not item:
                 return
                 
-            # Check for Artist Series
-            is_artist_series = self._is_artist_series(item, spec)
-            
-            # Check for Retouch (if any image codes or item flag indicate it)
-            is_retouch = self._is_retouch(image_codes or [], item)
-            
-            # Determine banner text
+            # Determine banner needs directly from item flags
+            needs_retouch = item.get("retouch", False)
+            needs_artist = item.get("artist_series", False)
+
+            if not (needs_retouch or needs_artist):
+                return
+
+            # Build banner text from the flags
             banner_text = None
-            if is_artist_series and is_retouch:
+            if needs_artist and needs_retouch:
                 banner_text = "ARTIST SERIES + RETOUCH"
-            elif is_artist_series:
+            elif needs_artist:
                 banner_text = "ARTIST SERIES"
-            elif is_retouch:
+            elif needs_retouch:
                 banner_text = "RETOUCH"
             
             # Only draw banner if one of the conditions is met

--- a/tests/test_fm_dump_parser.py
+++ b/tests/test_fm_dump_parser.py
@@ -64,3 +64,21 @@ def test_prestige_not_marked_retouch():
     comp = next(it for it in items if it.get("complimentary"))
     assert comp["finish"] == "PRESTIGE"
     assert not comp.get("retouch")
+
+def test_no_false_retouch():
+    """Ensure complimentary 8x10 items never get retouch flag by finish."""
+    tsv_path = Path(__file__).resolve().parents[1] / "fm_dump.tsv"
+    parsed = parse_fm_dump(str(tsv_path))
+
+    from app.order_from_tsv import rows_to_order_items
+    from app.config import load_product_config
+
+    products_cfg = load_product_config()
+    items = rows_to_order_items(parsed.rows, parsed.frames, products_cfg, parsed.retouch_imgs, parsed)
+
+    bogus = [
+        it for it in items
+        if it.get("display_name", "").startswith("Complimentary 8x10")
+        and it.get("retouch")
+    ]
+    assert not bogus, "Complimentary 8x10 incorrectly marked retouch"


### PR DESCRIPTION
## Summary
- stop using finish type as a retouch heuristic in overlay banner logic
- add regression test ensuring complimentary 8x10 items are not incorrectly marked retouch

## Testing
- `python test_preview_with_fm_dump.py fm_dump.tsv` *(fails: Retouch overlays logged for retouch codes)*
- `pytest -q` *(fails: ImportError: cannot import name 'BOUNDING_BOXES')*

------
https://chatgpt.com/codex/tasks/task_e_688922e14e48832d95369e82871b7a35