### PR TITLE
Update AHK to auto-select folder and generate preview

### DIFF
--- a/Visualizer.ahk
+++ b/Visualizer.ahk
@@ -5,6 +5,10 @@ global TotalFields := 103
 global ClipTimeoutMs := 80
 global InterKeyDelay := 10
 global OutputFile := A_Temp "\fm_dump.tsv"
+global PreviewImg := A_ScriptDir "\app\static\previews\fm_dump_preview.png"
+global PyScript := A_ScriptDir "\test_preview_with_fm_dump.py"
+global PythonExe := "python"
+global gShootDir := ""
 
 ; FM window match
 global FMExe := "ahk_exe FileMaker Pro.exe"
@@ -48,6 +52,15 @@ global FieldLabels := [
 ]
 ;-----------------------------------------
 
+; ====== AUTO-EXECUTE ======
+FileSelectFolder "Select Photographer Folder for the Day",, 3, &gShootDir
+if (!gShootDir) {
+    MsgBox "Folder not selected – exiting."
+    ExitApp
+}
+EnvSet "DROPBOX_ROOT", gShootDir
+return
+
 NumpadMult:: RunDump()
 Esc:: ExitApp
 
@@ -90,6 +103,13 @@ RunDump() {
     file := FileOpen(OutputFile, "w", "UTF-8")
     file.Write(buffer)
     file.Close()
+
+    cmd := Format('"%s" "%s" "%s"', PythonExe, PyScript, OutputFile)
+    RunWait cmd,, "Hide"
+    if (FileExist(PreviewImg))
+        Run PreviewImg
+    else
+        MsgBox "Preview image not found:`n" PreviewImg, "Warning", "Icon!"
 
     ; copy just values as TSV row if you still want that
     row := ""


### PR DESCRIPTION
## Summary
- prompt for photographer folder on startup and set `DROPBOX_ROOT`
- run `test_preview_with_fm_dump.py` after scraping FileMaker data
- automatically open the generated preview image

## Testing
- `python3 -m py_compile test_preview_with_fm_dump.py`

------
https://chatgpt.com/codex/tasks/task_e_6889609858f0832d84515602828741f2