### PR TITLE
Fix Dropbox path passing for preview generation

### DIFF
--- a/Visualizer.ahk
+++ b/Visualizer.ahk
@@ -60,6 +60,9 @@ if (!gShootDir) {
     MsgBox "Folder not selected – exiting."
     ExitApp
 }
+; Remove any trailing backslash to avoid quoting issues when launching Python
+if (SubStr(gShootDir, -1) == "\\")
+    gShootDir := SubStr(gShootDir, 1, -1)
 EnvSet "DROPBOX_ROOT", gShootDir
 return
 
@@ -107,10 +110,11 @@ RunDump() {
     file.Close()
 
 
-    ; Build the python command using proper Format placeholders
+    ; Build the python command using proper Format placeholders.
+    ; Pass the TSV path and the selected Dropbox folder to Python.
     ; AutoHotkey's Format() uses {} not %s, so %s produced the literal string
     ; "%s" "%s" "%s" and failed to execute.
-    cmd := Format('"{}" "{}" "{}"', PythonExe, PyScript, OutputFile)
+    cmd := Format('"{}" "{}" "{}" "{}"', PythonExe, PyScript, OutputFile, gShootDir)
 
     RunWait cmd,, "Hide"
     if (FileExist(PreviewImg))


### PR DESCRIPTION
## Summary
- let `test_preview_with_fm_dump.py` accept an optional Dropbox path argument
- update AHK script to pass the selected Dropbox folder to Python
- strip trailing backslash from selected folder to avoid command line quoting issues

## Testing
- `pip install Flask loguru python-dotenv pydantic PyYAML Pillow numpy opencv-python python-magic`
- `pytest -q` *(fails: fixture 'screenshot_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68896a8a10dc832db3ff84c926733cf5