### PR TITLE
Fix quoting for Dropbox path

### DIFF
--- a/Visualizer.ahk
+++ b/Visualizer.ahk
@@ -60,6 +60,9 @@ if (!gShootDir) {
     MsgBox "Folder not selected – exiting."
     ExitApp
 }
+; Remove trailing backslash to avoid quoting issues when launching Python
+if (SubStr(gShootDir, -1) == "\\")
+    gShootDir := SubStr(gShootDir, 1, -1)
 EnvSet "DROPBOX_ROOT", gShootDir
 return
 


### PR DESCRIPTION
## Summary
- sanitize trailing backslash from DROPBOX_ROOT so the preview script can read the temp TSV

## Testing
- `pip install Flask loguru python-dotenv pydantic PyYAML Pillow numpy opencv-python` *(fails: unsupported compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68896f4625dc832d8ba96cee543f3955