### PR TITLE
Fix asset paths for PyInstaller builds

### DIFF
--- a/app/enhanced_preview.py
+++ b/app/enhanced_preview.py
@@ -16,6 +16,7 @@ SAFE_PAD_PX = 40
 # Import trio composite functionality
 from .trio_composite import TrioCompositeGenerator, is_trio_product, trio_template_filename
 from .order_utils import _extract_size_from_item
+from .resource_utils import resource_path
 
 # Import frame overlay functionality
 from .frame_overlay import (
@@ -81,10 +82,10 @@ class EnhancedPortraitPreviewGenerator:
         self.master_images = {}  # Will store master cropped portraits
         
         # Initialize trio composite generator
-        self.trio_generator = TrioCompositeGenerator(Path("Composites"))
-        
+        self.trio_generator = TrioCompositeGenerator(resource_path("Composites"))
+
         # Initialize frame overlay engine
-        self.frame_engine = create_frame_overlay_engine()
+        self.frame_engine = create_frame_overlay_engine(resource_path("Frames"))
         
         logger.info(f"Enhanced preview generator V2 initialized with corrected scaling system")
     

--- a/app/frame_overlay.py
+++ b/app/frame_overlay.py
@@ -470,9 +470,9 @@ class FrameOverlayEngine:
         return frame_size_map.get(product_code)
 
 
-def create_frame_overlay_engine() -> FrameOverlayEngine:
-    """Factory function to create a frame overlay engine"""
-    frames_dir = Path("Frames")
+def create_frame_overlay_engine(frames_dir: Optional[Path] = None) -> FrameOverlayEngine:
+    """Factory function to create a frame overlay engine."""
+    frames_dir = frames_dir or Path("Frames")
     return FrameOverlayEngine(frames_dir)
 
 

--- a/app/resource_utils.py
+++ b/app/resource_utils.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+
+def resource_path(rel_path: str) -> Path:
+    """Resolve path to bundled resource for PyInstaller compatibility."""
+    base_path = Path(getattr(sys, "_MEIPASS", Path(".").resolve()))
+    return base_path / rel_path


### PR DESCRIPTION
## Summary
- add `resource_path` helper to handle `sys._MEIPASS`
- allow `create_frame_overlay_engine` to accept a directory
- load frames and composite templates via `resource_path`

## Testing
- `python -m py_compile app/enhanced_preview.py app/frame_overlay.py app/resource_utils.py`
- `python -m py_compile test_preview_with_fm_dump.py`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_688bb49de9f8832d8e207e1be122e76f