### PR TITLE
Fix resource lookup for composites

### DIFF
--- a/Visualizer.ahk
+++ b/Visualizer.ahk
@@ -114,7 +114,7 @@ RunDump() {
     ; Pass the TSV path and the selected Dropbox folder to Python.
     ; AutoHotkey's Format() uses {} not %s, so %s produced the literal string
     ; "%s" "%s" "%s" and failed to execute.
-    cmd := Format('"{}" "{}" "{}" "{}"', PythonExe, PyScript, OutputFile, gShootDir)
+    cmd := Format('"{1}" "{2}" "{3}" "{4}"', PythonExe, PyScript, OutputFile, gShootDir)
     
     ; Show what we're about to run (for debugging)
     ; MsgBox "Running command:`n" cmd, "Debug", "Iconi"

--- a/app/trio_composite.py
+++ b/app/trio_composite.py
@@ -146,9 +146,10 @@ class TrioComposite:
 
 class TrioCompositeGenerator:
     """Main class for generating trio composites with customer images"""
-    
-    def __init__(self, composites_dir: Path):
-        self.composites_dir = composites_dir
+
+    def __init__(self, base_dir: Path | str = "Composites"):
+        """Initialize generator with the directory containing composite files."""
+        self.base_dir = Path(base_dir)
         
         # Available frame and matte combinations (from composite files)
         self.available_combinations = [
@@ -245,11 +246,11 @@ class TrioCompositeGenerator:
         # Create and load composite
         composite = TrioComposite(frame_color, matte_color, size)
         scale = 1.0
-        if not composite.load_composite(self.composites_dir):
+        if not composite.load_composite(self.base_dir):
             if fallback_to_5x10 and size == "10x20":
                 logger.warning("10x20 composite not found, falling back to 5x10")
                 composite = TrioComposite(frame_color, matte_color, "5x10")
-                if not composite.load_composite(self.composites_dir):
+                if not composite.load_composite(self.base_dir):
                     return None
                 size = "5x10"
                 scale = 2.0


### PR DESCRIPTION
## Summary
- use numbered Format placeholders in AHK command
- allow TrioCompositeGenerator to take its base directory

## Testing
- `python -m py_compile app/trio_composite.py`
- `pip install -r requirements.txt` *(fails: Unsupported compiler)*

------
https://chatgpt.com/codex/tasks/task_e_688bb72b9aa4832d9d05130fb98dd0d4