### PR TITLE
Add config setup and resource helpers

### DIFF
--- a/app/image_search.py
+++ b/app/image_search.py
@@ -6,11 +6,22 @@ Based on 4-digit codes from FileMaker wishlist
 import re
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple, Set
+from glob import glob
 from loguru import logger
 from PIL import Image
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 import time
+
+
+def find_all_images(root: Path) -> Dict[str, Path]:
+    """Recursively map image codes to file paths."""
+    patterns = ["**/*.jpg", "**/*.jpeg", "**/*.png"]
+    files: Dict[str, Path] = {}
+    for pat in patterns:
+        for path in root.glob(pat):
+            files[path.stem] = path
+    return files
 
 
 class OptimizedDropboxImageSearcher:

--- a/app/resource_utils.py
+++ b/app/resource_utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 from pathlib import Path
 
 
@@ -7,3 +8,13 @@ def resource_path(rel_path: str) -> Path:
     """Resolve path to bundled resource for PyInstaller compatibility."""
     base_path = Path(getattr(sys, "_MEIPASS", Path(".").resolve()))
     return base_path / rel_path
+
+
+def ensure_resource_dirs():
+    """Ensure bundled asset folders exist in the working directory."""
+    for name in ("Composites", "Frames"):
+        dst = Path(name)
+        if not dst.exists() or not any(dst.iterdir()):
+            src = resource_path(name)
+            if src.exists():
+                shutil.copytree(src, dst, dirs_exist_ok=True)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "photo_root": "C:/Users/remem/Dropbox/PHOTOGRAPHER UPLOADS",
+  "composites_dir": "Composites",
+  "frames_dir": "Frames"
+}

--- a/test_preview_with_fm_dump.py
+++ b/test_preview_with_fm_dump.py
@@ -9,6 +9,8 @@ variable.
 """
 
 import sys
+import os
+import json
 from pathlib import Path
 from typing import List
 
@@ -20,6 +22,11 @@ from app.config import load_product_config, load_config
 from app.image_search import create_image_searcher
 from app.enhanced_preview import EnhancedPortraitPreviewGenerator
 from app.order_from_tsv import rows_to_order_items
+from app.resource_utils import ensure_resource_dirs
+
+CONFIG = json.load(open(Path(__file__).with_name("config.json"), "r"))
+os.environ.setdefault("DROPBOX_ROOT", CONFIG.get("photo_root", ""))
+ensure_resource_dirs()
 
 
 def _expand_extremes(order_items: List[dict]) -> List[dict]:


### PR DESCRIPTION
## Summary
- bundle a portable `config.json` for photo root config
- ensure composites and frames directories exist at runtime
- add simple recursive image crawler utility
- load `config.json` and assets in the preview script

## Testing
- `pytest -q` *(fails: fixture 'screenshot_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bdf8cc99c832dbcdd2cc646639f0c