### PR TITLE
Implement pythonw fallback in Visualizer launcher

### DIFF
--- a/Visualizer.ahk
+++ b/Visualizer.ahk
@@ -148,8 +148,15 @@ RunDump() {
     ; "%s" "%s" "%s" and failed to execute.
     ; Build and run the python command in one step to avoid quoting issues
     ; using numbered placeholders. Format here mirrors a standard %s pattern.
+    ; Prefer pythonw.exe to avoid showing a console window
+    pyw := A_AppData "\Programs\Python\Python311\pythonw.exe"
+    if !FileExist(pyw)
+        pyw := "C:\\Python311\\pythonw.exe"
+    if !FileExist(pyw)
+        pyw := "python.exe"  ; final fallback shows console
+
     try {
-        RunWait Format('"%s" "%s" "%s" "%s"', PythonExe, PyScript, OutputFile, gShootDir),
+        RunWait Format('"%s" "%s" "%s" "%s"', pyw, PyScript, OutputFile, gShootDir),
                A_ScriptDir, "Hide"
         if (FileExist(PreviewImg)) {
             Run PreviewImg


### PR DESCRIPTION
## Summary
- avoid console windows by preferring `pythonw.exe` in Visualizer

## Testing
- `pip install -r requirements.txt` *(fails: Unsupported compiler for winrt packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688c0d3942e4832d8ff9028b9b10653e