### PR TITLE
Update launcher quoting and resource checks

### DIFF
--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -179,9 +179,9 @@ RunDump() {
     MsgBox "Starting Python visualizer...`nThe preview will open when ready.",
            "Running Visualizer", "Iconi"
 
+    cmd := Format('"%s" "%s" "%s" "%s"', pyw, script, OutputFile, gShootDir)
     try {
-        ExitCode := RunWait(Format('"%s" "%s" "%s" "%s"', pyw, script, OutputFile, gShootDir),
-                            WorkingDir, "Hide")
+        ExitCode := RunWait(cmd, WorkingDir, "Hide")
 
         if FileExist(PreviewImg) {
             Run PreviewImg
@@ -193,9 +193,8 @@ RunDump() {
                    "Missing Preview", "Icon!"
         }
     } catch Error as e {
-        errCmd := Format('"%s" "%s" "%s" "%s"', pyw, script, OutputFile, gShootDir)
         MsgBox "❌ Error launching Python script:`n" e.Message "`n`n" .
-               "Command: " errCmd "`n`n" .
+               "Command: " cmd "`n`n" .
                "Working directory: " WorkingDir,
                "Error", "Iconx"
     }

--- a/Visualizer.ahk
+++ b/Visualizer.ahk
@@ -7,7 +7,6 @@ global InterKeyDelay := 100
 global OutputFile := A_ScriptDir "\fm_dump.tsv"
 global PreviewImg := A_ScriptDir "\app\static\previews\fm_dump_preview.png"
 global PyScript := A_ScriptDir "\test_preview_with_fm_dump.py"
-global PythonExe := "python"
 global gShootDir := ""
 
 ; FM window match
@@ -155,9 +154,9 @@ RunDump() {
     if !FileExist(pyw)
         pyw := "python.exe"  ; final fallback shows console
 
+    cmd := Format('"%s" "%s" "%s" "%s"', pyw, PyScript, OutputFile, gShootDir)
     try {
-        RunWait Format('"%s" "%s" "%s" "%s"', pyw, PyScript, OutputFile, gShootDir),
-               A_ScriptDir, "Hide"
+        RunWait cmd, A_ScriptDir, "Hide"
         if (FileExist(PreviewImg)) {
             Run PreviewImg
             MsgBox "Preview generated successfully!`nOpening: " PreviewImg, "Success", "Iconi"
@@ -165,8 +164,7 @@ RunDump() {
             MsgBox "Preview image not found:`n" PreviewImg "`n`nCheck if Python script ran successfully.", "Warning", "Icon!"
         }
     } catch Error as e {
-        errCmd := Format('"%s" "%s" "%s" "%s"', PythonExe, PyScript, OutputFile, gShootDir)
-        MsgBox "Error running Python script:`n" e.Message "`n`nCommand was:`n" errCmd, "Error", "Iconx"
+        MsgBox "Error running Python script:`n" e.Message "`n`nCommand was:`n" cmd, "Error", "Iconx"
     }
 
     ; copy just values as TSV row if you still want that


### PR DESCRIPTION
## Summary
- launch Python with a fully formatted command line
- simplify error reporting

## Testing
- `pytest -q` *(fails: fixture 'screenshot_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c113942f0832db0069e967e28539e