### PR TITLE
Fix asset generation for 10x20 composites

### DIFF
--- a/app/resource_utils.py
+++ b/app/resource_utils.py
@@ -2,6 +2,7 @@ import os
 import sys
 import shutil
 from pathlib import Path
+from PIL import Image
 
 
 def resource_path(rel_path: str) -> Path:
@@ -20,8 +21,31 @@ def ensure_resource_dirs() -> None:
             if src.exists():
                 shutil.copytree(src, dst, dirs_exist_ok=True)
 
+    # Auto-generate 10x20 composites if missing
+    generate_10x20_composites(Path("Composites"))
+
     cfg_dst = Path("config.json")
     if not cfg_dst.exists():
         cfg_src = resource_path("config.json")
         if cfg_src.exists():
             shutil.copy(cfg_src, cfg_dst)
+
+
+def generate_10x20_composites(composites_dir: Path) -> None:
+    """Create 10x20 composite images by doubling existing 5x10 files."""
+    if not composites_dir.exists():
+        return
+
+    for file in composites_dir.glob("*5x10 3 Image.jpg"):
+        target_name = file.name.replace("5x10", "10x20")
+        target = composites_dir / target_name
+        if target.exists():
+            continue
+
+        try:
+            img = Image.open(file)
+            doubled = img.resize((img.width * 2, img.height * 2), Image.Resampling.LANCZOS)
+            doubled.save(target, format="JPEG")
+        except Exception:
+            continue
+


### PR DESCRIPTION
## Summary
- ensure default assets copy also generates 10x20 composite frames

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688c141f2e98832d82031a2c6039493c