### PR TITLE
Fix quoting for Python command

### DIFF
--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -179,7 +179,7 @@ RunDump() {
     MsgBox "Starting Python visualizer...`nThe preview will open when ready.",
            "Running Visualizer", "Iconi"
 
-    cmd := Format('"%s" "%s" "%s" "%s"', pyw, script, OutputFile, gShootDir)
+    cmd := Format('"{1}" "{2}" "{3}" "{4}"', pyw, script, OutputFile, gShootDir)
     try {
         ExitCode := RunWait(cmd, WorkingDir, "Hide")
 


### PR DESCRIPTION
## Summary
- update command format in the AutoHotkey script to use numbered placeholders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688c1b772e68832db83451583bb3305e