### PR TITLE
Fix asset detection for first-run previews

### DIFF
--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -166,6 +166,12 @@ RunDump() {
     file.Write(buffer)
     file.Close()
 
+    ; Ensure asset folders exist on first launch
+    if !DirExist(A_ScriptDir "\Composites") && DirExist(A_ScriptDir "\assets\Composites")
+        DirCopy A_ScriptDir "\assets\Composites", A_ScriptDir "\Composites", 1
+    if !DirExist(A_ScriptDir "\Frames") && DirExist(A_ScriptDir "\assets\Frames")
+        DirCopy A_ScriptDir "\assets\Frames", A_ScriptDir "\Frames", 1
+
 
     ; Build Python command without batch wrappers or extra console window
     ; Prefer pythonw.exe to suppress any console if available
@@ -180,6 +186,7 @@ RunDump() {
            "Running Visualizer", "Iconi"
 
     cmd := Format('"{1}" "{2}" "{3}" "{4}"', pyw, script, OutputFile, gShootDir)
+    EnvSet "DROPBOX_ROOT", gShootDir
     try {
         ExitCode := RunWait(cmd, WorkingDir, "Hide")
 


### PR DESCRIPTION
## Summary
- ensure Composites and Frames are copied from `assets` if those folders are missing
- pass `DROPBOX_ROOT` to the child process just before launching Python

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: unsupported wheel build on linux)*

------
https://chatgpt.com/codex/tasks/task_e_688c1d482c60832db90561dd7bf12e05