### PR TITLE
Add log capture for Python errors

### DIFF
--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -185,8 +185,9 @@ RunDump() {
     MsgBox "Starting Python visualizer...`nThe preview will open when ready.",
            "Running Visualizer", "Iconi"
 
-    cmd := Format('"{1}" "{2}" "{3}" "{4}"', pyw, script, OutputFile, gShootDir)
     EnvSet "DROPBOX_ROOT", gShootDir
+    cmd := Format('"{1}" "{2}" "{3}" "{4}" > "%5\\python_err.log" 2>&1',
+                  pyw, script, OutputFile, gShootDir, WorkingDir)
     try {
         ExitCode := RunWait(cmd, WorkingDir, "Hide")
 


### PR DESCRIPTION
## Summary
- log Python errors by redirecting stdout and stderr to `python_err.log`
- set `DROPBOX_ROOT` before building the command

## Testing
- `python -m py_compile app/*.py test_preview_with_fm_dump.py`
- `pip install -q -r requirements.txt` *(fails: `Failed building wheel for winrt-windows-foundation`)*

------
https://chatgpt.com/codex/tasks/task_e_688c1f3131d8832d9b1837ef63cad7d3