### PR TITLE
Fix quoting in AHK python command

### DIFF
--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -188,7 +188,7 @@ RunDump() {
     EnvSet "DROPBOX_ROOT", gShootDir ; set before the run
     logFile := WorkingDir "\python_err.log"
     cmd := Format(
-        '%ComSpec% /c ""{1}" "{2}" "{3}" "{4}" -u 1> "{5}" 2>&1"',
+        '%ComSpec% /c ""{1}" "{2}" "{3}" "{4}" -u 1^> "{5}" 2^>^&1"',
         pyExe, PyScript, OutputFile, gShootDir, logFile)
     try {
         ExitCode := RunWait(cmd, WorkingDir, "Hide")


### PR DESCRIPTION
## Summary
- escape redirection characters in the Visualizer's AHK script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c2aa90814832da91fe815a1efc535