### PR TITLE
Improve Python interpreter lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,9 @@ If the visualizer fails to generate a preview the easiest way to diagnose the pr
 | `FileNotFoundError: Composites\Frame Cherry - Tan 10x20 3 Image.jpg` | A required asset is missing or the path is wrong. |
 | `OSError: [WinError 193] %1 is not a valid Win32 application` | The wrong Python executable was used. |
 
+The launcher now checks the Windows registry for a CPython 3.11 install before
+falling back to bundled paths or the `py.exe` launcher. If you still get a
+"system cannot find the file specified" message, verify that a standard Python
+installation exists or adjust the registry lookup to match your version.
+
 Once the exception is known the fix is usually a one‑liner. After applying the fix run the preview again and re-check `python_err.log` for any new errors.

--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -174,13 +174,18 @@ RunDump() {
 
 
     ; Build Python command without batch wrappers or extra console window
-    ; Prefer pythonw.exe to suppress any console if available
-    if FileExist(A_AppData "\Programs\Python\Python311\pythonw.exe")
+    ; Prefer an absolute interpreter path from the registry if available
+    try RegRead exe, 'HKLM\SOFTWARE\Python\PythonCore\3.11\InstallPath', 'ExecutablePath'
+    catch
+        exe := ''
+    if (exe && FileExist(exe))
+        pyExe := exe
+    else if FileExist(A_AppData "\Programs\Python\Python311\pythonw.exe")
         pyExe := A_AppData "\Programs\Python\Python311\pythonw.exe"
     else if FileExist('C:\\Python311\\pythonw.exe')
         pyExe := 'C:\\Python311\\pythonw.exe'
     else
-        pyExe := 'python.exe'
+        pyExe := 'py.exe'
 
     MsgBox "Starting Python visualizer...`nThe preview will open when ready.",
            "Running Visualizer", "Iconi"


### PR DESCRIPTION
## Summary
- check the Windows registry for Python 3.11 in the AHK launcher
- fall back to bundled paths or `py.exe`
- document registry lookup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c332c5d8c832db6d890aa9c09b368