### PR TITLE
Fix RunWait parameter count

### DIFF
--- a/Visualizer (3).ahk
+++ b/Visualizer (3).ahk
@@ -194,6 +194,8 @@ RunDump() {
         pyExe := 'C:\\Python311\\pythonw.exe'
     else if (pyExe = '' && FileExist('C:\\Python311\\python.exe'))
         pyExe := 'C:\\Python311\\python.exe'
+    else if (pyExe = '' && FileExist(A_AppData '\\Programs\\Python\\Python311\\pythonw.exe'))
+        pyExe := A_AppData '\\Programs\\Python\\Python311\\pythonw.exe'
     else if (pyExe = '')                          ; last resort
         pyExe := 'py.exe'                          ; works only if launcher installed
 
@@ -205,7 +207,7 @@ RunDump() {
     cmd := [pyExe, PyScript, OutputFile, gShootDir, "-u"]
     try {
         FileDelete logFile
-        ExitCode := RunWait(cmd, WorkingDir, "Hide", , &out)
+        ExitCode := RunWait(cmd, WorkingDir, "Hide", &out)
         FileAppend out, logFile
         if ExitCode
             FileAppend "`n--- script exited " ExitCode " ---`n", logFile


### PR DESCRIPTION
## Summary
- adjust python path search to include AppData directory
- call `RunWait` with only four parameters so the script launches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c38fd64dc832d9c676a71dfe8e0c8